### PR TITLE
Add Bowtie2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 !resources/*
 !rules
 !rules/*
+!rules/mappers
+!rules/mappers/*
 !rules/preproc
 !rules/preproc/*
 !rules/taxonomic_profiling

--- a/Snakefile
+++ b/Snakefile
@@ -6,29 +6,53 @@
 # Running snakemake -n in a clone of this repository should successfully
 # execute a test dry-run of the workflow.
 
+from sys import exit
+import os.path
+
 configfile: "config.yaml"
 outdir = config["outdir"]
 all_outputs = []
 
-SAMPLES = glob_wildcards(config["inputdir"]+"/"+config["input_fn_pattern"]).sample
+SAMPLES = set(glob_wildcards(config["inputdir"]+"/"+config["input_fn_pattern"]).sample)
 
 
 if config["qc_reads"]:
     include: "rules/preproc/read_quality.smk"
-    fastqc_input = expand("{outdir}/fastqc/{sample}_R{readpair}.{ext}", outdir=outdir, sample=SAMPLES, readpair=[1,2], ext=["zip", "html"])
-    trimmed_qa = expand("{outdir}/trimmed_qa/{sample}_R{readpair}.trimmed_qa.fq.gz", outdir=outdir, sample=SAMPLES, readpair=[1,2])
+    fastqc_input = expand("{outdir}/fastqc/{sample}_R{readpair}.{ext}",
+            outdir=outdir,
+            sample=SAMPLES,
+            readpair=[1,2],
+            ext=["zip", "html"])
+    trimmed_qa = expand("{outdir}/trimmed_qa/{sample}_R{readpair}.trimmed_qa.fq.gz",
+            outdir=outdir,
+            sample=SAMPLES,
+            readpair=[1,2])
     all_outputs.extend(fastqc_input)
     all_outputs.extend(trimmed_qa)
 
 
 if config["remove_human"]:
     include: "rules/preproc/remove_human.smk"
-    filtered_human = expand("{outdir}/filtered_human/{sample}_R{readpair}.filtered_human.fq.gz", outdir=outdir, sample=SAMPLES, readpair=[1,2])
+    filtered_human = expand("{outdir}/filtered_human/{sample}_R{readpair}.filtered_human.fq.gz",
+            outdir=outdir,
+            sample=SAMPLES,
+            readpair=[1,2])
     all_outputs.extend(filtered_human)
     hg19_db_dir = config["dbdir"]+"/hg19"
     hg19_db_file = "hg19_main_mask_ribo_animal_allplant_allfungus.fa"
     if not os.path.exists(os.path.join(hg19_db_dir, hg19_db_file)):
-        all_outputs.extend(expand("{dbdir}/{dbfile}", dbdir=hg19_db_dir, dbfile=hg19_db_file))
+        all_outputs.extend(expand("{dbdir}/{dbfile}",
+                dbdir=hg19_db_dir,
+                dbfile=hg19_db_file))
+
+
+if config["mappers"]["bowtie2"]:
+    include: "rules/mappers/bowtie2.smk"
+    bowtie2_alignments = expand("{outdir}/bowtie2/{db_name}/{sample}.bam",
+            outdir=outdir,
+            sample=SAMPLES,
+            db_name=bt2_db_name)
+    all_outputs.extend(bowtie2_alignments)
 
 
 if config["taxonomic_profile"]:

--- a/Snakefile
+++ b/Snakefile
@@ -52,7 +52,13 @@ if config["mappers"]["bowtie2"]:
             outdir=outdir,
             sample=SAMPLES,
             db_name=bt2_db_name)
+    bowtie2_stats = expand("{outdir}/bowtie2/{db_name}/{sample}.{stats}.txt",
+            outdir=outdir,
+            sample=SAMPLES,
+            stats=["covstats", "rpkm"],
+            db_name=bt2_db_name)
     all_outputs.extend(bowtie2_alignments)
+    all_outputs.extend(bowtie2_stats)
 
 
 if config["taxonomic_profile"]:

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,9 @@ dbdir: "databases"
 #########################
 qc_reads: True
 remove_human: True
-taxonomic_profile: True
+mappers:
+    bowtie2: True
+taxonomic_profile: False
 
 
 #########################
@@ -42,6 +44,13 @@ bbmap_removehuman_trimq: 10
 bbmap_removehuman_quickmatch: "quickmatch"
 bbmap_removehuman_fast: "fast"
 bbmap_removehuman_untrim: "untrim"
+
+#########################
+# Mappers
+#########################
+bowtie2:
+    db_prefix: ""         # Full path to Bowtie2 index (not including file extension)
+    extra: ""             # Extra bowtie2 commandline parameters
 
 
 #########################

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -9,6 +9,7 @@ if not any([os.path.isfile(config["bowtie2"]["db_prefix"]+ext) for ext in bt2_db
     raise WorkflowError(err_message)
 bt2_db_name = os.path.basename(config["bowtie2"]["db_prefix"])
 
+
 rule bowtie2:
     """Align reads using Bowtie2."""
     input:
@@ -26,3 +27,25 @@ rule bowtie2:
     wrapper:
         "0.23.1/bio/bowtie2/align"
 
+
+rule bowtie2_mapping_stats:
+    """Summarize bowtie2 mapping statistics."""
+    input:
+        bam=config["outdir"]+"/bowtie2/{dbname}/{{sample}}.bam".format(dbname=bt2_db_name)
+    output:
+        covstats=config["outdir"]+"/bowtie2/{dbname}/{{sample}}.covstats.txt".format(dbname=bt2_db_name),
+        rpkm=config["outdir"]+"/bowtie2/{dbname}/{{sample}}.rpkm.txt".format(dbname=bt2_db_name)
+    log:
+        config["outdir"]+"/logs/bowtie2/{dbname}/{{sample}}.pileup.log".format(dbname=bt2_db_name)
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/bbmap.yaml"
+    shell:
+        """
+        pileup.sh \
+            in={input.bam} \
+            out={output.covstats} \
+            rpkm={output.rpkm} \
+            > {log}
+        """

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -1,0 +1,28 @@
+# Generic rules for alignment of reads to a reference database using Bowtie2
+from snakemake.exceptions import WorkflowError
+import os.path
+
+bt2_db_extensions = (".1.bt2", ".1.bt2l")
+if not any([os.path.isfile(config["bowtie2"]["db_prefix"]+ext) for ext in bt2_db_extensions]):
+    err_message = "Bowtie2 index not found at: '{}'\n".format(config["bowtie2"]["db_prefix"])
+    err_message += "Check path in config setting 'bowtie2:db_prefix'."
+    raise WorkflowError(err_message)
+bt2_db_name = os.path.basename(config["bowtie2"]["db_prefix"])
+
+rule bowtie2:
+    """Align reads using Bowtie2."""
+    input:
+        sample=[config["outdir"]+"/filtered_human/{sample}_R1.filtered_human.fq.gz",
+                config["outdir"]+"/filtered_human/{sample}_R2.filtered_human.fq.gz"]
+    output:
+        config["outdir"]+"/bowtie2/{db_name}/{{sample}}.bam".format(db_name=bt2_db_name)
+    log:
+        config["outdir"]+"/logs/bowtie2/{db_name}/{{sample}}.log".format(db_name=bt2_db_name)
+    params:
+        index=config["bowtie2"]["db_prefix"],
+        extra=config["bowtie2"]["extra"],
+    threads:
+        8
+    wrapper:
+        "0.23.1/bio/bowtie2/align"
+


### PR DESCRIPTION
Add bowtie2 mapping step. Introduces new hierarchy in `config.yaml` to select which mappers to run. Also introduces new `rules/mappers` folder that will contain rules for different mappers. Also adds read counts, coverage statistics, etc via `pileup.sh` from BBTools. 