### PR TITLE
Add taxonomic profiler: Centrifuge. Closes #5

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -60,6 +60,20 @@ if config["mappers"]["bowtie2"]:
     all_outputs.extend(bowtie2_stats)
 
 
+if config["taxonomic_profile"]["centrifuge"]:
+    include: "rules/taxonomic_profiling/centrifuge.smk"
+    centrifuge = expand("{outdir}/centrifuge/{sample}.{output_type}.tsv",
+            outdir=outdir,
+            sample=SAMPLES,
+            output_type=("centrifuge", "centrifuge_report"))
+    all_outputs.extend(centrifuge)
+    if not config["centrifuge"]["db_prefix"]:
+        print("WARNING: No Centrifuge database specified!\n"
+              "         Specify Centrifuge database prefix in the Centrifuge section of config.yaml.\n"
+              "         Run 'snakemake download_centrifuge_database' to download a copy into '{dbdir}/centrifuge'\n".format(dbdir=config["dbdir"]) +
+              "         If you do not want to run Centrifuge for taxonomic profiling, set centrifuge: False in config.yaml")
+
+
 if config["taxonomic_profile"]["kaiju"]:
     include: "rules/taxonomic_profiling/kaiju.smk"
     kaiju = expand("{outdir}/kaiju/{sample}.kaiju", outdir=outdir, sample=SAMPLES)

--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ remove_human: True
 mappers:
     bowtie2: True
 taxonomic_profile:
+    centrifuge: True
     kaiju: True
 
 
@@ -59,6 +60,9 @@ bowtie2:
 #########################
 # Taxonomic profiling
 #########################
+centrifuge:
+    db_prefix: ""        # Path to Centrifuge DB index (i.e. not including file extensions)
+
 kaiju:
     db: ""               # Path to Kaiju DB file
     nodes: ""            # Path to Kaiju taxonomy nodes.dmp

--- a/envs/centrifuge.yaml
+++ b/envs/centrifuge.yaml
@@ -1,0 +1,6 @@
+channels:
+    - bioconda
+    - conda-forge
+    - defaults
+dependencies:
+    - centrifuge =1.0.3

--- a/rules/taxonomic_profiling/centrifuge.smk
+++ b/rules/taxonomic_profiling/centrifuge.smk
@@ -1,0 +1,48 @@
+# vim: syntax=python expandtab
+# Taxonomic classification of metagenomic reads using Centrifuge
+
+rule download_centrifuge_database:
+    output:
+        db=[config["dbdir"]+"/centrifuge/p+h+v.{n}.cf".format(n=num) for num in (1,2,3)]
+    shadow:
+        "shallow"
+    params:
+        dbdir=config["dbdir"]+"/centrifuge"
+    shell:
+        """
+        cd {params.dbdir}
+        wget ftp://ftp.ccb.jhu.edu/pub/infphilo/centrifuge/data/p+h+v.tar.gz \
+        && \
+        tar -xf p+h+v.tar.gz \
+        && \
+        rm p+h+v.tar.gz
+        """
+
+
+cf_config = config["centrifuge"]
+rule centrifuge:
+    input:
+        read1=config["outdir"]+"/filtered_human/{sample}_R1.filtered_human.fq.gz",
+        read2=config["outdir"]+"/filtered_human/{sample}_R2.filtered_human.fq.gz",
+    output:
+        classifications=config["outdir"]+"/centrifuge/{sample}.centrifuge.tsv",
+        report=config["outdir"]+"/centrifuge/{sample}.centrifuge_report.tsv",
+    log:
+        config["outdir"]+"/logs/centrifuge/{sample}.centrifuge.log"
+    shadow: 
+        "shallow"
+    conda:
+        "../../envs/centrifuge.yaml"
+    params:
+        db_prefix=cf_config["db_prefix"],
+    shell:
+        """
+        centrifuge \
+            -x {params.db_prefix} \
+            -1 {input.read1} \
+            -2 {input.read2} \
+            -S {output.classifications} \
+            --report-file {output.report} \
+            2> {log}
+        """
+


### PR DESCRIPTION
This PR adds Centrifuge as an alternative taxonomic profiling tool. It includes a rule, `download_centrifuge_database`, that can be manually triggered to download the complete bacteria, archaea, human, virus database database (just run `snakemake download_centrifuge_database` to run only that rule).

