### PR TITLE
Metaphlan2

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -87,6 +87,20 @@ if config["taxonomic_profile"]["kaiju"]:
               "         If you do not want to run Kaiju for taxonomic profiling, set 'kaiju: False' in config.yaml")
 
 
+if config["taxonomic_profile"]["metaphlan2"]:
+    include: "rules/taxonomic_profiling/metaphlan2.smk"
+    mpa_outputs = expand("{outdir}/metaphlan2/{sample}.{output_type}",
+            outdir=outdir,
+            sample=SAMPLES,
+            output_type=("bowtie2.bz2", "metaphlan2.txt"))
+    all_outputs.extend(mpa_outputs)
+    if not any([config["metaphlan2"]["mpa_pkl"], config["metaphlan2"]["bt2_db_prefix"]]):
+        print("WARNING: No MetaPhlAn2 database specified!\n"
+              "         Specify relevant paths in the metaphlan2 section of config.yaml.\n"
+              "         Run 'snakemake build_metaphlan2_index' to download and build the default mpa_v20_m200 database in '{dbdir}/metaphlan2'\n".format(dbdir=config["dbdir"]) +
+              "         If you do not want to run MetaPhlAn2 for taxonomic profiling, set metaphlan2: False in config.yaml")
+
+
 rule all:
     input:
         all_outputs

--- a/Snakefile
+++ b/Snakefile
@@ -93,7 +93,10 @@ if config["taxonomic_profile"]["metaphlan2"]:
             outdir=outdir,
             sample=SAMPLES,
             output_type=("bowtie2.bz2", "metaphlan2.txt"))
+    mpa_combined = expand("{outdir}/metaphlan2/all_samples.metaphlan2.txt",
+            outdir=outdir)
     all_outputs.extend(mpa_outputs)
+    all_outputs.extend(mpa_combined)
     if not any([config["metaphlan2"]["mpa_pkl"], config["metaphlan2"]["bt2_db_prefix"]]):
         print("WARNING: No MetaPhlAn2 database specified!\n"
               "         Specify relevant paths in the metaphlan2 section of config.yaml.\n"

--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,7 @@ mappers:
 taxonomic_profile:
     centrifuge: True
     kaiju: True
+    metaphlan2: True
 
 
 #########################
@@ -67,3 +68,9 @@ kaiju:
     db: ""               # Path to Kaiju DB file
     nodes: ""            # Path to Kaiju taxonomy nodes.dmp
     names: ""            # Path to Kaiju taxonomy names.dmp
+
+metaphlan2:
+    mpa_pkl: ""          # Path to MetaPhlAn2 pickle file: db_v20_m200.pkl
+    bt2_db_prefix: ""    # Path to MetaPhlAn2 Bowtie2 index prefix: /path/to/db_v20_m200 (no file extension)
+    extra: ""            # Extra command line arguments for metaphlan2.py
+

--- a/config.yaml
+++ b/config.yaml
@@ -17,11 +17,11 @@ dbdir: "databases"       # Databases will be downloaded to this dir, if requeste
 qc_reads: True
 remove_human: True
 mappers:
-    bowtie2: True
+    bowtie2: False
 taxonomic_profile:
-    centrifuge: True
-    kaiju: True
-    metaphlan2: True
+    centrifuge: False
+    kaiju: False
+    metaphlan2: False
 
 
 #########################

--- a/envs/metaphlan2.yaml
+++ b/envs/metaphlan2.yaml
@@ -1,0 +1,7 @@
+channels:
+    - bioconda
+    - conda-forge
+    - defaults
+dependencies:
+    - metaphlan2 =2.6.0
+    - krona =2.7

--- a/rules/taxonomic_profiling/metaphlan2.smk
+++ b/rules/taxonomic_profiling/metaphlan2.smk
@@ -1,0 +1,91 @@
+# vim: syntax=python expandtab
+# Taxonomic classification of metagenomic reads using MetaPhlAn2
+
+rule download_metaphlan2_database:
+    """Download MetaPhlAn2 db_v20_m200"""
+    output:
+        config["dbdir"]+"/metaphlan2/mpa_v20_m200.fna",
+        config["dbdir"]+"/metaphlan2/mpa_v20_m200.pkl",
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/metaphlan2.yaml"
+    params:
+        dbdir=config["dbdir"]+"/metaphlan2"
+    shell:
+        """
+        cd {params.dbdir}
+        wget https://bitbucket.org/biobakery/metaphlan2/downloads/mpa_v20_m200.tar \
+        && \
+        tar -xf mpa_v20_m200.tar \
+        && \
+        bunzip2 mpa_v20_m200.fna.bz2 \
+        && \
+        rm -v mpa_v20_m200.tar
+        """
+
+
+rule build_metaphlan2_index:
+    """Build MetaPhlAn2 bowtie2 index."""
+    input:
+        config["dbdir"]+"/metaphlan2/mpa_v20_m200.fna"
+    output:
+        [config["dbdir"]+"/metaphlan2/mpa_v20_m200.{n}.bt2".format(n=num) for num in (1,2,3,4)],
+        [config["dbdir"]+"/metaphlan2/mpa_v20_m200.rev.{n}.bt2".format(n=num) for num in (1,2)],
+    log:
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/metaphlan2.yaml"
+    threads:
+        4
+    params:
+        dbdir=config["dbdir"]+"/metaphlan2"
+    shell:
+        """
+        cd {params.dbdir}
+        bowtie2-build \
+            mpa_v20_m200.fna \
+            mpa_v20_m200 \
+            --threads {threads}
+        """
+
+
+mpa_config = config["metaphlan2"]
+rule metaphlan2:
+    """Taxonomic profiling using MetaPhlAn2."""
+    input:
+        read1=config["outdir"]+"/filtered_human/{sample}_R1.filtered_human.fq.gz",
+        read2=config["outdir"]+"/filtered_human/{sample}_R2.filtered_human.fq.gz",
+    output:
+        bt2_out=config["outdir"]+"/metaphlan2/{sample}.bowtie2.bz2",
+        mpa_out=config["outdir"]+"/metaphlan2/{sample}.metaphlan2.txt",
+    log:
+        stdout=config["outdir"]+"/logs/metaphlan2/{sample}.metaphlan2.stdout.log",
+        stderr=config["outdir"]+"/logs/metaphlan2/{sample}.metaphlan2.stderr.log",
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/metaphlan2.yaml"
+    threads:
+        4
+    params:
+        mpa_pkl=mpa_config["mpa_pkl"],
+        bt2_db_prefix=mpa_config["bt2_db_prefix"],
+        extra=mpa_config["extra"],
+    shell:
+        """
+        metaphlan2.py \
+            --input_type fastq \
+            --nproc {threads} \
+            --sample_id {wildcards.sample} \
+            --bowtie2out {output.bt2_out} \
+            --mpa_pkl {params.mpa_pkl} \
+            --bowtie2db {params.bt2_db_prefix} \
+            {input.read1},{input.read2} \
+            {output.mpa_out} \
+            {params.extra} \
+            > {log.stdout} \
+            2> {log.stderr}
+        """
+

--- a/rules/taxonomic_profiling/metaphlan2.smk
+++ b/rules/taxonomic_profiling/metaphlan2.smk
@@ -89,3 +89,21 @@ rule metaphlan2:
             2> {log.stderr}
         """
 
+
+rule combine_metaphlan2_outputs:
+    """Combine metaphlan2 outputs into a large table."""
+    input:
+        expand(config["outdir"]+"/metaphlan2/{sample}.metaphlan2.txt", sample=SAMPLES)
+    output:
+        config["outdir"]+"/metaphlan2/all_samples.metaphlan2.txt"
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/metaphlan2.yaml"
+    threads:
+        1
+    shell:
+        """
+        merge_metaphlan_tables.py {input} > {output}
+        """
+


### PR DESCRIPTION
This PR adds a set of MetaPhlAn2 rules. 
One of the rules enables automatic download of the required MetaPhlAn2 marker gene database by calling `snakemake build_metaphlan2_index`. There is a rule that combines all MetaPhlAn2 outputs into a single table at the end. I'm thinking to extend this to produce Krona plots for all mpa2 outputs as well. 

One more thing: as StaG-mwc is becoming larger and larger I decided to set all steps to `False` except for the preprocessing steps. It makes it easier to get started without being hit with a ton of warning messages about missing databases etc when you have just downloaded the workflow and try running it for the first time. 