### PR TITLE
Add BBMap for generic read mapping

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -45,6 +45,16 @@ if config["remove_human"]:
               "         Run 'snakemake index_hg19' to download and create a BBMap index in '{dbdir}/hg19'".format(dbdir=config["dbdir"]))
 
 
+if config["mappers"]["bbmap"]:
+    include: "rules/mappers/bbmap.smk"
+    bbmap_alignments = expand("{outdir}/bbmap/{db_name}/{sample}.{output_type}",
+            outdir=outdir,
+            db_name=config["bbmap"]["db_name"],
+            sample=SAMPLES,
+            output_type=("sam.gz", "covstats.txt", "rpkm.txt"))
+    all_outputs.extend(bbmap_alignments)
+
+
 if config["mappers"]["bowtie2"]:
     include: "rules/mappers/bowtie2.smk"
     bowtie2_alignments = expand("{outdir}/bowtie2/{db_name}/{sample}.bam",

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,12 @@
 # vim: syntax=python expandtab
-# mwc global configuration file
+#
+#     StaG Metagenomic Workflow Collaboration
+#                 configuration file
+#
+# Configuration settings marked with [Required] are only required if the
+# pipeline step for that setting is included. Set which steps to include
+# under the "Pipeline steps included" heading. The default settings are to
+# only run read preprocessing steps.
 
 
 #########################
@@ -40,7 +47,7 @@ bbduk:
     trimbyoverlap: "trimbyoverlap"
     trimpairsevenly: "trimpairsevenly"
 remove_human:
-    hg19_path: ""        # Path to folder containing the BBMap index for hg19
+    hg19_path: ""        # [Required] Path to folder containing the BBMap index for hg19
     minid: 0.95
     maxindel: 3
     minhits: 2
@@ -56,12 +63,12 @@ remove_human:
 # Mappers
 #########################
 bbmap:
-    db_name: ""           # [Required] custom name for BBMap database
+    db_name: ""           # [Required] Custom name for BBMap database
     db_path: ""           # [Required] Path to BBMap database (folder should contain a 'ref' folder)
     min_id: 0.76          # Minimum id for read alignment, BBMap default is 0.76
     extra: ""             # Extra BBMap command line parameters
 bowtie2:
-    db_prefix: ""         # Full path to Bowtie2 index (not including file extension)
+    db_prefix: ""         # [Required] Full path to Bowtie2 index (not including file extension)
     extra: ""             # Extra bowtie2 commandline parameters
 
 
@@ -69,16 +76,16 @@ bowtie2:
 # Taxonomic profiling
 #########################
 centrifuge:
-    db_prefix: ""        # Path to Centrifuge DB index (i.e. not including file extensions)
+    db_prefix: ""        # [Required] Path to Centrifuge DB index (i.e. not including file extensions)
 
 kaiju:
-    db: ""               # Path to Kaiju DB file
-    nodes: ""            # Path to Kaiju taxonomy nodes.dmp
-    names: ""            # Path to Kaiju taxonomy names.dmp
+    db: ""               # [Required] Path to Kaiju DB file
+    nodes: ""            # [Required] Path to Kaiju taxonomy nodes.dmp
+    names: ""            # [Required] Path to Kaiju taxonomy names.dmp
 
 metaphlan2:
-    mpa_pkl: ""          # Path to MetaPhlAn2 pickle file: db_v20_m200.pkl
-    bt2_db_prefix: ""    # Path to MetaPhlAn2 Bowtie2 index prefix: /path/to/db_v20_m200 (no file extension)
+    mpa_pkl: ""          # [Required] Path to MetaPhlAn2 pickle file: db_v20_m200.pkl
+    bt2_db_prefix: ""    # [Required] Path to MetaPhlAn2 Bowtie2 index prefix: /path/to/db_v20_m200 (no file extension)
     extra: ""            # Extra command line arguments for metaphlan2.py
 
 
@@ -86,7 +93,7 @@ metaphlan2:
 # Antibiotic Resistance
 #########################
 megares:
-    dbpath: ""           # Path to folder containing MEGARes BBMap index
+    dbpath: ""           # [Required] Path to folder containing MEGARes BBMap index
     min_id: 0.91
     max_indel: 1600      # BBMap default is 16000
     extra: ""            # Extra BBMap commandline parameters

--- a/config.yaml
+++ b/config.yaml
@@ -17,12 +17,14 @@ dbdir: "databases"       # Databases will be downloaded to this dir, if requeste
 qc_reads: True
 remove_human: True
 mappers:
+    bbmap: False
     bowtie2: False
 taxonomic_profile:
     centrifuge: False
     kaiju: False
     metaphlan2: False
 antibiotic_resistance: False
+
 
 #########################
 # Read quality assessment
@@ -53,6 +55,11 @@ remove_human:
 #########################
 # Mappers
 #########################
+bbmap:
+    db_name: ""           # [Required] custom name for BBMap database
+    db_path: ""           # [Required] Path to BBMap database (folder should contain a 'ref' folder)
+    min_id: 0.76          # Minimum id for read alignment, BBMap default is 0.76
+    extra: ""             # Extra BBMap command line parameters
 bowtie2:
     db_prefix: ""         # Full path to Bowtie2 index (not including file extension)
     extra: ""             # Extra bowtie2 commandline parameters

--- a/rules/mappers/bbmap.smk
+++ b/rules/mappers/bbmap.smk
@@ -1,0 +1,49 @@
+# Rules for generic read mapping using BBMap
+from snakemake.exceptions import WorkflowError
+import os.path
+
+if not os.path.isdir(config["bbmap"]["db_path"]):
+    err_message = "BBMap index not found at: '{}'\n".format(config["bbmap"]["db_path"])
+    err_message += "Check path in config setting 'bbmap:db_path'.\n"
+    err_message += "If you want to skip mapping with BBMap, set mappers:bbmap:False in config.yaml."
+    raise WorkflowError(err_message)
+
+bbmap_config = config["bbmap"]
+bbmap_output_folder = config["outdir"]+"/bbmap/{db_name}/".format(db_name=bbmap_config["db_name"])
+rule bbmap:
+    """BBMap"""
+    input:
+        read1=config["outdir"]+"/filtered_human/{sample}_R1.filtered_human.fq.gz",
+        read2=config["outdir"]+"/filtered_human/{sample}_R2.filtered_human.fq.gz",
+    output:
+        sam=bbmap_output_folder+"{sample}.sam.gz",
+        covstats=bbmap_output_folder+"{sample}.covstats.txt",
+        rpkm=bbmap_output_folder+"{sample}.rpkm.txt",
+    log:
+        stdout=config["outdir"]+"/logs/bbmap/{sample}.bbmap.stdout.log",
+        stderr=config["outdir"]+"/logs/bbmap/{sample}.bbmap.statsfile.txt"
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/bbmap.yaml"
+    threads:
+        8
+    params:
+        db_path=bbmap_config["db_path"],
+        min_id=bbmap_config["min_id"],
+        extra=bbmap_config["extra"],
+    shell:
+        """
+        bbmap.sh \
+            threads={threads} \
+            minid={params.min_id} \
+            path={params.db_path} \
+            in1={input.read1} \
+            in2={input.read2} \
+            out={output.sam} \
+            covstats={output.covstats} \
+            rpkm={output.rpkm} \
+            {params.extra} \
+            > {log.stdout} \
+            2> {log.stderr}
+        """


### PR DESCRIPTION
This PR adds BBMap as an optional step to the workflow, to map against any database that the user provides.

It also cleans up the config file a bit. Closes #6 