### PR TITLE
Add MinHash sketch-based all-vs-all sample comparison PDF plot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@
 !rules/mappers/*
 !rules/preproc
 !rules/preproc/*
+!rules/sketch_compare
+!rules/sketch_compare/*
 !rules/taxonomic_profiling
 !rules/taxonomic_profiling/*
 !samples.tsv

--- a/Snakefile
+++ b/Snakefile
@@ -45,6 +45,13 @@ if config["remove_human"]:
               "         Run 'snakemake index_hg19' to download and create a BBMap index in '{dbdir}/hg19'".format(dbdir=config["dbdir"]))
 
 
+if config["sketch_compare"]:
+    include: "rules/sketch_compare/sketch_compare.smk"
+    sample_similarity_plot = expand("{outdir}/sketch_compare/sample_similarity.pdf",
+            outdir=outdir)
+    all_outputs.extend(sample_similarity_plot)
+
+
 if config["mappers"]["bbmap"]:
     include: "rules/mappers/bbmap.smk"
     bbmap_alignments = expand("{outdir}/bbmap/{db_name}/{sample}.{output_type}",

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,7 @@ dbdir: "databases"       # Databases will be downloaded to this dir, if requeste
 #########################
 qc_reads: True
 remove_human: True
+sketch_compare: False
 mappers:
     bbmap: False
     bowtie2: False

--- a/envs/python.yaml
+++ b/envs/python.yaml
@@ -1,0 +1,5 @@
+channels:
+    - defaults
+dependencies:
+    - pandas =0.22.0
+    - seaborn =0.8.1

--- a/rules/sketch_compare/sketch_compare.smk
+++ b/rules/sketch_compare/sketch_compare.smk
@@ -1,0 +1,70 @@
+# vim: syntax=python expandtab
+# Compare all samples against all samples using MinHash sketches
+
+rule sketch:
+    """Create MinHash sketches of samples using BBMap's sketch.sh"""
+    input:
+        "input/{sample}_R1.fastq.gz"
+    output:
+        sketch=config["outdir"]+"/sketch_compare/{sample}.sketch.gz",
+    log:
+        config["outdir"]+"/logs/sketch_compare/{sample}.sketch.log"
+    shadow: 
+        "shallow"
+    conda:
+        "../../envs/bbmap.yaml"
+    threads:
+        2
+    shell:
+        """
+        sketch.sh \
+            in={input} \
+            out={output} \
+            name0={wildcards.sample} \
+            2> {log}
+        """
+
+
+rule compare_sketches:
+    """Compare all samples using BBMap's comparesketch.sh"""
+    input:
+        samples=expand(config["outdir"]+"/sketch_compare/{sample}.sketch.gz",
+                sample=SAMPLES)
+    output:
+        alltoall=config["outdir"]+"/sketch_compare/alltoall.txt",
+    log:
+        config["outdir"]+"/logs/sketch_compare/comparesketch.log"
+    shadow: 
+        "shallow"
+    conda: 
+        "../../envs/bbmap.yaml"
+    shell:
+        """
+        comparesketch.sh \
+            format=3 \
+            out={output} \
+            alltoall \
+            {input} \
+            2> {log}
+        """
+
+
+rule plot_sample_similarity:
+    """Plot sample sketch similarity matrix"""
+    input:
+        config["outdir"]+"/sketch_compare/alltoall.txt"
+    output:
+        config["outdir"]+"/sketch_compare/sample_similarity.pdf"
+    log:
+        stdout=config["outdir"]+"/logs/sketch_compare/sample_similarity_plot.stdout.log",
+        stderr=config["outdir"]+"/logs/sketch_compare/sample_similarity_plot.stderr.log",
+    conda:
+        "../../python.yaml"
+    shell:
+        """
+        scripts/plot_sketch_comparison_heatmap.py \
+            --outfile {output} \
+            {input} \
+            > {log.stdout} \
+            2> {log.stderr}
+        """

--- a/scripts/plot_sketch_comparison_heatmap.py
+++ b/scripts/plot_sketch_comparison_heatmap.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# Plot heatmap of MinHash sketch comparisons by BBTool's sketch.sh/comparesketch.sh.
+# Fredrik Boulund 2018
+
+from sys import argv, exit
+import argparse
+
+import matplotlib as mpl
+mpl.use("agg")
+import pandas as pd
+import seaborn as sns
+
+
+def parse_args():
+    desc = "Plot heatmap of sketch comparisons."
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument("alltoall", metavar="alltoall",
+            help="Output table from comparesketch.sh in format=3.")
+    parser.add_argument("-o", "--outfile", dest="outfile", metavar="FILE",
+            default="all_vs_all.pdf",
+            help="Write heatmap plot to FILE [%(default)s].")
+    if len(argv) < 2:
+        parser.print_help()
+        exit(1)
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    options = parse_args()
+    
+    colnames = ["Query", "Ref", "ANI", "QSize", "RefSize", "QBases"]
+    df = pd.read_csv(
+            options.alltoall, 
+            sep="\t", 
+            index_col=False, 
+            skiprows=1,
+            names=colnames)
+    print("Loaded data for {} sample comparisons.".format(df.shape[0]))
+
+    similarity_matrix = df.pivot(index="Query", 
+            columns="Ref", values="ANI").fillna(100)
+
+    g = sns.heatmap(similarity_matrix)
+    g.set_title("Sample similarity")
+    g.set_yticklabels(g.get_yticklabels(), rotation=0)
+    g.set_ylabel("")
+    g.set_xlabel("")
+
+    g.get_figure().savefig(options.outfile)


### PR DESCRIPTION
This PR adds MinHash-based all-vs-all sample comparisons using BBMap's `sketch.sh`/`comparesketch.sh` tools. It plots a simple summary heatmap plot of the all-vs-all similarity matrix using [Seaborn](http://seaborn.pydata.org/). It's a rough tool, but it's quick to run, requires little resources, and hopefully gives a quick and easy-to-look-at plot to assess overall sample similarity.

I set it to be off by default in `config.yaml`. 

Closes #16 