### PR TITLE
Feature counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ scripts/.snakemake*
 !Snakefile
 !.test
 !.travis.yml
+!utils
+!utils/*

--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,7 @@ bbmap:
     min_id: 0.76             # Minimum id for read alignment, BBMap default is 0.76
     extra: ""                # Extra BBMap command line parameters
     featureCounts:
-        annotations: ""      # [Required] Full path to GTF format annotations for database sequences
+        annotations: ""      # [Required] Full path to GTF format annotations for database sequences. If not set, featureCounts summary will be skipped.
         feature_type: ""     # Feature type to produce counts for, default is "gene"
         attribute_type: ""   # Attribute type to summarize counts for, default is "gene_id" (any attribute in the GTF file's attribute field can be used)
         extra: ""            # Extra featureCount command line parameters
@@ -80,7 +80,7 @@ bowtie2:
     db_prefix: ""            # [Required] Full path to Bowtie2 index (not including file extension)
     extra: ""                # Extra bowtie2 commandline parameters
     featureCounts:
-        annotations: ""      # [Required] Full path to GTF format annotations for database sequences
+        annotations: ""      # [Required] Full path to GTF format annotations for database sequences. If not set, featureCounts summary will be skipped.
         feature_type: ""     # Feature type to produce counts for, default is "gene"
         attribute_type: ""   # Attribute type to summarize counts for, default is "gene_id" (any attribute in the GTF file's attribute field can be used)
         extra: ""            # Extra featureCount command line parameters

--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,7 @@
 inputdir: "input"
 input_fn_pattern: "{sample}_R{readpair}.fastq.gz" 
 outdir: "output_dir"
-dbdir: "databases"       # Databases will be downloaded to this dir, if requested
+dbdir: "databases"           # Databases will be downloaded to this dir, if requested
 
 
 #########################
@@ -49,7 +49,7 @@ bbduk:
     trimbyoverlap: "trimbyoverlap"
     trimpairsevenly: "trimpairsevenly"
 remove_human:
-    hg19_path: ""         # [Required] Path to folder containing the BBMap index for hg19
+    hg19_path: ""            # [Required] Path to folder containing the BBMap index for hg19
     minid: 0.95
     maxindel: 3
     minhits: 2
@@ -61,51 +61,56 @@ remove_human:
     fast: "fast"
     untrim: "untrim"
 bbcountunique:
-    interval: 5000        # Typically set to 10000, but test data requires <=5035
+    interval: 5000           # Typically set to 10000, but test data requires <=5035
 
 #########################
 # Mappers
 #########################
 bbmap:
-    db_name: ""           # [Required] Custom name for BBMap database
-    db_path: ""           # [Required] Path to BBMap database (folder should contain a 'ref' folder)
-    min_id: 0.76          # Minimum id for read alignment, BBMap default is 0.76
-    extra: ""             # Extra BBMap command line parameters
+    db_name: ""              # [Required] Custom name for BBMap database
+    db_path: ""              # [Required] Path to BBMap database (folder should contain a 'ref' folder)
+    min_id: 0.76             # Minimum id for read alignment, BBMap default is 0.76
+    extra: ""                # Extra BBMap command line parameters
 bowtie2:
-    db_prefix: ""         # [Required] Full path to Bowtie2 index (not including file extension)
-    extra: ""             # Extra bowtie2 commandline parameters
+    db_prefix: ""            # [Required] Full path to Bowtie2 index (not including file extension)
+    extra: ""                # Extra bowtie2 commandline parameters
+    featureCounts:
+        annotations: ""      # [Required] Full path to GTF format annotations for database sequences
+        feature_type: ""     # Feature type to produce counts for, default is "gene"
+        attribute_type: ""   # Attribute type to summarize counts for, default is "gene_id" (any attribute in the GTF file's attribute field can be used)
+        extra: ""            # Extra featureCount command line parameters
 
 
 #########################
 # Taxonomic profiling
 #########################
 centrifuge:
-    db_prefix: ""        # [Required] Path to Centrifuge DB index (not including file extension)
+    db_prefix: ""            # [Required] Path to Centrifuge DB index (not including file extension)
 
 kaiju:
-    db: ""               # [Required] Path to Kaiju DB file
-    nodes: ""            # [Required] Path to Kaiju taxonomy nodes.dmp
-    names: ""            # [Required] Path to Kaiju taxonomy names.dmp
+    db: ""                   # [Required] Path to Kaiju DB file
+    nodes: ""                # [Required] Path to Kaiju taxonomy nodes.dmp
+    names: ""                # [Required] Path to Kaiju taxonomy names.dmp
 
 metaphlan2:
-    mpa_pkl: ""          # [Required] Path to MetaPhlAn2 pickle file: mpa_v20_m200.pkl
-    bt2_db_prefix: ""    # [Required] Path to MetaPhlAn2 Bowtie2 index prefix: /path/to/mpa_v20_m200 (no file extension)
-    extra: ""            # Extra command line arguments for metaphlan2.py
-    tax_lev: "s"         # Heatmap: Taxononomic level, choose from a, k, p, c, f, g, s
-    minv: "0"            # Heatmap: Minimum value to display.
-    s: "log"             # Heatmap: Scale, default is "norm"
-    top: "50"            # Heatmap: Top most abundant taxa to display
-    m: "average"         # Heatmap: Hierarchical clustering method.
-    d: "braycurtis"      # Heatmap: Distance function for samples.
-    f: "correlation"     # Heatmap: Distance function for microbes.
-    c: "jet"             # Heatmap: Colormap, default is "jet"
+    mpa_pkl: ""              # [Required] Path to MetaPhlAn2 pickle file: mpa_v20_m200.pkl
+    bt2_db_prefix: ""        # [Required] Path to MetaPhlAn2 Bowtie2 index prefix: /path/to/mpa_v20_m200 (no file extension)
+    extra: ""                # Extra command line arguments for metaphlan2.py
+    tax_lev: "s"             # Heatmap: Taxononomic level, choose from a, k, p, c, f, g, s
+    minv: "0"                # Heatmap: Minimum value to display.
+    s: "log"                 # Heatmap: Scale, default is "norm"
+    top: "50"                # Heatmap: Top most abundant taxa to display
+    m: "average"             # Heatmap: Hierarchical clustering method.
+    d: "braycurtis"          # Heatmap: Distance function for samples.
+    f: "correlation"         # Heatmap: Distance function for microbes.
+    c: "jet"                 # Heatmap: Colormap, default is "jet"
 
 
 #########################
 # Antibiotic Resistance
 #########################
 megares:
-    db_path: ""          # [Required] Path to folder containing MEGARes BBMap index
+    db_path: ""              # [Required] Path to folder containing MEGARes BBMap index
     min_id: 0.91
-    max_indel: 1600      # BBMap default is 16000
-    extra: ""            # Extra BBMap commandline parameters
+    max_indel: 1600          # BBMap default is 16000
+    extra: ""                # Extra BBMap commandline parameters

--- a/config.yaml
+++ b/config.yaml
@@ -71,6 +71,11 @@ bbmap:
     db_path: ""              # [Required] Path to BBMap database (folder should contain a 'ref' folder)
     min_id: 0.76             # Minimum id for read alignment, BBMap default is 0.76
     extra: ""                # Extra BBMap command line parameters
+    featureCounts:
+        annotations: ""      # [Required] Full path to GTF format annotations for database sequences
+        feature_type: ""     # Feature type to produce counts for, default is "gene"
+        attribute_type: ""   # Attribute type to summarize counts for, default is "gene_id" (any attribute in the GTF file's attribute field can be used)
+        extra: ""            # Extra featureCount command line parameters
 bowtie2:
     db_prefix: ""            # [Required] Full path to Bowtie2 index (not including file extension)
     extra: ""                # Extra bowtie2 commandline parameters

--- a/envs/stag-mwc.yaml
+++ b/envs/stag-mwc.yaml
@@ -12,3 +12,4 @@ dependencies:
     - matplotlib =2.2.2
     - pandas =0.22.0
     - seaborn =0.8.1
+    - subread =1.6.0

--- a/rules/mappers/bbmap.smk
+++ b/rules/mappers/bbmap.smk
@@ -93,6 +93,7 @@ rule bbmap_featureCounts:
         feature_type=lambda _: fc_config["feature_type"] if fc_config["feature_type"] else "gene",
         attribute_type=lambda _: fc_config["attribute_type"] if fc_config["attribute_type"] else "gene_id",
         extra=fc_config["extra"],
+        dbname=bbmap_config["db_name"],
     shell:
         """
         featureCounts \
@@ -110,6 +111,6 @@ rule bbmap_featureCounts:
             -f1,7- \
             {output.counts}  \
             | sed '1d' \
-            | sed 's|\t\w\+/bbmap/\w\+/|\t|g' \
+            | sed 's|\t\w\+/bbmap/{params.dbname}/|\t|g' \
             > {output.counts_table}
         """

--- a/rules/mappers/bbmap.smk
+++ b/rules/mappers/bbmap.smk
@@ -7,12 +7,6 @@ if not os.path.isdir(os.path.join(config["bbmap"]["db_path"], "ref")):
     err_message += "Check path in config setting 'bbmap:db_path'.\n"
     err_message += "If you want to skip mapping with BBMap, set mappers:bbmap:False in config.yaml."
     raise WorkflowError(err_message)
-if not os.path.isfile(config["bbmap"]["featureCounts"]["annotations"]):
-    err_message = "BBMap featureCounts annotations not found at: '{}'\n".format(config["bbmap"]["featureCounts"]["annotations"])
-    err_message += "Check path in config setting 'bbmap:featureCounts:annotations'.\n"
-    err_message += "If you want to skip mapping with BBMap, set mappers:bbmap:False in config.yaml."
-    raise WorkflowError(err_message)
-
 
 # Add final output files from this module to 'all_outputs' from the main
 # Snakefile scope. SAMPLES is also from the main Snakefile scope.
@@ -27,7 +21,13 @@ featureCounts = expand("{outdir}/bbmap/{db_name}/all_samples.featureCounts{outpu
         sample=SAMPLES,
         output_type=["", ".summary", ".table.tsv"])
 all_outputs.extend(bbmap_alignments)
-all_outputs.extend(featureCounts)
+if config["bbmap"]["featureCounts"]["annotations"]:
+    if not os.path.isfile(config["bbmap"]["featureCounts"]["annotations"]):
+        err_message = "BBMap featureCounts annotations not found at: '{}'\n".format(config["bbmap"]["featureCounts"]["annotations"])
+        err_message += "Check path in config setting 'bbmap:featureCounts:annotations'.\n"
+        err_message += "If you want to skip mapping with BBMap, set mappers:bbmap:False in config.yaml."
+        raise WorkflowError(err_message)
+    all_outputs.extend(featureCounts)
 
 bbmap_config = config["bbmap"]
 bbmap_output_folder = config["outdir"]+"/bbmap/{db_name}/".format(db_name=bbmap_config["db_name"])

--- a/rules/mappers/bbmap.smk
+++ b/rules/mappers/bbmap.smk
@@ -86,6 +86,8 @@ rule bbmap_featureCounts:
         "shallow"
     conda:
         "../../envs/stag-mwc.yaml"
+    threads:
+        4
     params:
         annotations=fc_config["annotations"],
         feature_type=lambda _: fc_config["feature_type"] if fc_config["feature_type"] else "gene",
@@ -98,6 +100,7 @@ rule bbmap_featureCounts:
             -o {output.counts} \
             -t {params.feature_type} \
             -g {params.attribute_type} \
+            -T {threads} \
             {params.extra} \
             {input.bams} \
             > {log} \

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -8,6 +8,11 @@ if not any([os.path.isfile(config["bowtie2"]["db_prefix"]+ext) for ext in bt2_db
     err_message += "Check path in config setting 'bowtie2:db_prefix'.\n"
     err_message += "If you want to skip mapping with bowtie2, set mappers:bowtie2:False in config.yaml."
     raise WorkflowError(err_message)
+if not os.path.isfile(config["bowtie2"]["featureCounts"]["annotations"]):
+    err_message = "Bowtie2 featureCounts annotations not found at: '{}'\n".format(config["bowtie2"]["featureCounts"]["annotations"])
+    err_message += "Check path in config setting 'bowtie2:featureCounts:annotations'.\n"
+    err_message += "If you want to skip mapping with Bowtie2, set mappers:bowtie2:False in config.yaml."
+    raise WorkflowError(err_message)
 bt2_db_name = os.path.basename(config["bowtie2"]["db_prefix"])
 
 # Add final output files from this module to 'all_outputs' from the main

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -21,8 +21,14 @@ bowtie2_stats = expand("{outdir}/bowtie2/{db_name}/{sample}.{stats}.txt",
         sample=SAMPLES,
         stats=["covstats", "rpkm"],
         db_name=bt2_db_name)
+featureCounts = expand("{outdir}/bowtie2/{db_name}/all_samples.featureCounts{output_type}",
+        outdir=config["outdir"],
+        db_name=bt2_db_name,
+        sample=SAMPLES,
+        output_type=["", ".summary", ".table.tsv"])
 all_outputs.extend(bowtie2_alignments)
 all_outputs.extend(bowtie2_stats)
+all_outputs.extend(featureCounts)
 
 rule bowtie2:
     """Align reads using Bowtie2."""
@@ -62,4 +68,45 @@ rule bowtie2_mapping_stats:
             out={output.covstats} \
             rpkm={output.rpkm} \
             2> {log}
+        """
+
+fc_config = config["bowtie2"]["featureCounts"]
+rule bowtie2_featureCounts:
+    input:
+        bams=expand(config["outdir"]+"/bowtie2/{dbname}/{sample}.bam",
+                dbname=bt2_db_name,
+                sample=SAMPLES)
+    output:
+        counts=config["outdir"]+"/bowtie2/{dbname}/all_samples.featureCounts".format(dbname=bt2_db_name),
+        counts_table=config["outdir"]+"/bowtie2/{dbname}/all_samples.featureCounts.table.tsv".format(dbname=bt2_db_name),
+        summary=config["outdir"]+"/bowtie2/{dbname}/all_samples.featureCounts.summary".format(dbname=bt2_db_name),
+    log:
+        config["outdir"]+"/logs/bowtie2/{dbname}/all_samples.featureCounts.log".format(dbname=bt2_db_name)
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/stag-mwc.yaml"
+    params:
+        annotations=fc_config["annotations"],
+        feature_type=lambda x: fc_config["feature_type"] if fc_config["feature_type"] else "gene",
+        attribute_type=lambda x: fc_config["attribute_type"] if fc_config["attribute_type"] else "gene_id",
+        extra=fc_config["extra"],
+    shell:
+        """
+        featureCounts \
+            -a {params.annotations} \
+            -o {output.counts} \
+            -t {params.feature_type} \
+            -g {params.attribute_type} \
+            {params.extra} \
+            {input.bams} \
+            > {log} \
+            2>> {log} \
+        && \
+        cut \
+            -f1,7- \
+            {output.counts}  \
+            | sed '1d' \
+            | sed 's|\t\w\+/bowtie2/\w\+/|\t|g' \
+            > {output.counts_table}
         """

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -8,11 +8,6 @@ if not any([os.path.isfile(config["bowtie2"]["db_prefix"]+ext) for ext in bt2_db
     err_message += "Check path in config setting 'bowtie2:db_prefix'.\n"
     err_message += "If you want to skip mapping with bowtie2, set mappers:bowtie2:False in config.yaml."
     raise WorkflowError(err_message)
-if not os.path.isfile(config["bowtie2"]["featureCounts"]["annotations"]):
-    err_message = "Bowtie2 featureCounts annotations not found at: '{}'\n".format(config["bowtie2"]["featureCounts"]["annotations"])
-    err_message += "Check path in config setting 'bowtie2:featureCounts:annotations'.\n"
-    err_message += "If you want to skip mapping with Bowtie2, set mappers:bowtie2:False in config.yaml."
-    raise WorkflowError(err_message)
 bt2_db_name = os.path.basename(config["bowtie2"]["db_prefix"])
 
 # Add final output files from this module to 'all_outputs' from the main
@@ -33,7 +28,13 @@ featureCounts = expand("{outdir}/bowtie2/{db_name}/all_samples.featureCounts{out
         output_type=["", ".summary", ".table.tsv"])
 all_outputs.extend(bowtie2_alignments)
 all_outputs.extend(bowtie2_stats)
-all_outputs.extend(featureCounts)
+if config["bowtie2"]["featureCounts"]["annotations"]:
+    if not os.path.isfile(config["bowtie2"]["featureCounts"]["annotations"]):
+        err_message = "Bowtie2 featureCounts annotations not found at: '{}'\n".format(config["bowtie2"]["featureCounts"]["annotations"])
+        err_message += "Check path in config setting 'bowtie2:featureCounts:annotations'.\n"
+        err_message += "If you want to skip mapping with Bowtie2, set mappers:bowtie2:False in config.yaml."
+        raise WorkflowError(err_message)
+    all_outputs.extend(featureCounts)
 
 rule bowtie2:
     """Align reads using Bowtie2."""

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -91,6 +91,8 @@ rule bowtie2_featureCounts:
         "shallow"
     conda:
         "../../envs/stag-mwc.yaml"
+    threads:
+        4
     params:
         annotations=fc_config["annotations"],
         feature_type=lambda x: fc_config["feature_type"] if fc_config["feature_type"] else "gene",
@@ -103,6 +105,7 @@ rule bowtie2_featureCounts:
             -o {output.counts} \
             -t {params.feature_type} \
             -g {params.attribute_type} \
+            -T {threads} \
             {params.extra} \
             {input.bams} \
             > {log} \

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -98,6 +98,7 @@ rule bowtie2_featureCounts:
         feature_type=lambda x: fc_config["feature_type"] if fc_config["feature_type"] else "gene",
         attribute_type=lambda x: fc_config["attribute_type"] if fc_config["attribute_type"] else "gene_id",
         extra=fc_config["extra"],
+        dbname=bt2_db_name,
     shell:
         """
         featureCounts \
@@ -115,6 +116,6 @@ rule bowtie2_featureCounts:
             -f1,7- \
             {output.counts}  \
             | sed '1d' \
-            | sed 's|\t\w\+/bowtie2/\w\+/|\t|g' \
+            | sed 's|\t\w\+/bowtie2/{params.dbname}/|\t|g' \
             > {output.counts_table}
         """

--- a/utils/convert_IGC_annotation.py
+++ b/utils/convert_IGC_annotation.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Fredrik Boulund
+# 2018-04-24
+"""Convert IGC annotation file to GTF or SAF."""
+
+from sys import argv, exit, stderr
+from functools import partial
+import argparse
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("IGC_ANNOTATION", 
+            help="IGC annotation file. Typically 'IGC.annotation_OF.summary'. "
+            "Can convert IGC_MEDUSA's CombinedNRGenesReduces.KEGG.txt to GTF "
+            "format if used with '-f igc_medusa'.")
+    parser.add_argument("-f", "--format",
+            default="gtf",
+            choices=["gtf", "saf", "igc_medusa"],
+            help="Output format SAF or GTF [%(default)s].")
+    parser.add_argument("-a", "--annotation-type", dest="annotation_type",
+            default="eggnog",
+            choices=["eggnog", "kegg", "phylum", "genus", "kegg_func", "eggnog_func"],
+            help="Annotation type to put in SAF format GeneID column [%(default)s].")
+    parser.add_argument("--gene-lengths", dest="gene_lengths",
+            default="",
+            help="Path to two-column tab-separated file containing sequence length (col 1)"
+                 "and sequence name (col 2). Only used to convert igc_medusa, and if "
+                 "not supplied, the script will set the gene length of all genes to "
+                 "45297, which is the maximum observed gene length in igc_medusa "
+                 "2018-04-24.")
+
+    if len(argv) < 2:
+        parser.print_help()
+        exit(1)
+
+    return parser.parse_args()
+
+
+def parse_igc_annotation(annotation_file):
+    """
+    Yield lines from IGC annotation summary file as tuples:
+        (gene_id, gene_name, gene_length, gene_completeness,
+            cohort, phylum, genus, kegg, eggnog, sample_occurence_freq,
+            individual_occurence_freq, kegg_func_cat, eggnog_func_cat,
+            cohort) = line.split("\t")
+    """
+    with open(annotation_file) as f:
+        for line_no, line in enumerate(f, start=1):
+            try:
+                yield line.strip().split("\t")
+            except ValueError:
+                print("ERROR parsing line {}:\n{}".format(line_no, line), 
+                        file=stderr)
+                exit(1)
+
+def parse_gene_lengths(gene_lengths_file):
+    gene_lengths = {}
+    with open(gene_lengths_file) as f:
+        for line_no, line in enumerate(f, start=1):
+            try:
+                length, gene_name = line.strip().split()
+                gene_lengths[gene_name] = length
+            except ValueError:
+                print("ERROR parsing gene_lengths, line {}:\n{}".format(line_no, line),
+                        file=stderr)
+                exit(1)
+    return gene_lengths
+
+
+def convert_medusa_to_gtf(annotation_lines, gene_lengths, max_seqlen=45297):
+    """
+    Convert IGC_medusa to very basic GTF format.
+    max_seqlen is the length of longest sequence in the database,
+    which will be used as the length of all seqs in the GTF.
+    """
+    gtf_line = "{seqname}\t{source}\t{feature}\t{start}\t{end}\t{score}\t{strand}\t{frame}\t{attribute}"
+    for gene_id, kegg in annotation_lines:
+        print(gtf_line.format(
+                    seqname=gene_id,
+                    source="IGC_medusa",
+                    feature="gene",
+                    start="1",
+                    end=gene_lengths.get(gene_id, max_seqlen),
+                    score=".",
+                    strand="+",
+                    frame="0",
+                    attribute="; ".join(['gene_id "{}"'.format(kegg)]))
+        )
+
+
+def convert_to_saf(annotation_lines, annotation_type):
+    saf_line = "{GeneID}\t{Chr}\t{Start}\t{End}\t{Strand}"
+    print(saf_line.format(GeneID="GeneID", Chr="Chr", Start="Start", End="End", Strand="Strand"))
+    for (gene_id, gene_name, gene_length, gene_completeness,
+         cohort, phylum, genus, kegg, eggnog, sample_occurence_freq,
+         individual_occurence_freq, kegg_func_cat, eggnog_func_cat,
+         cohort) in annotation_lines:
+        if annotation_type == "eggnog":
+            GeneID = eggnog
+        elif annotation_type == "kegg":
+            GeneID = kegg
+        elif annotation_type == "phylum":
+            GeneID = phylum
+        elif annotation_type == "genus":
+            GeneID = genus
+        elif annotation_type == "kegg_func":
+            GeneID = kegg_func_cat
+        elif annotation_type == "eggnog_func":
+            GeneID = eggnog_func_cat
+        else:
+            GeneID = gene_id
+        print(saf_line.format(
+                    GeneID=GeneID,
+                    Chr=gene_name,
+                    Start="1",
+                    End=gene_length,
+                    Strand="+"))
+
+
+def convert_to_gtf(annotation_lines):
+    gtf_line = "{seqname}\t{source}\t{feature}\t{start}\t{end}\t{score}\t{strand}\t{frame}\t{attribute}"
+    for (gene_id, gene_name, gene_length, gene_completeness,
+         cohort, phylum, genus, kegg, eggnog, sample_occurence_freq,
+         individual_occurence_freq, kegg_func_cat, eggnog_func_cat,
+         cohort) in annotation_lines:
+        print(gtf_line.format(
+                    seqname=gene_name,
+                    source="IGC",
+                    feature="gene",
+                    start="1",
+                    end=gene_length,
+                    score=".",
+                    strand="+",
+                    frame="0",
+                    attribute="; ".join(['gene_id "{}"'.format(gene_name),
+                                         'gene_completeness "{}"'.format(gene_completeness),
+                                         'cohort "{}"'.format(cohort),
+                                         'phylum "{}"'.format(phylum),
+                                         'genus "{}"'.format(genus),
+                                         'kegg "{}"'.format(kegg),
+                                         'eggnog "{}"'.format(eggnog),
+                                         'sample_occurence_freq "{}"'.format(sample_occurence_freq),
+                                         'individual_occurence_freq "{}"'.format(individual_occurence_freq),
+                                         'kegg_func_cat "{}"'.format(kegg_func_cat),
+                                         'eggnog_func_cat "{}"'.format(eggnog_func_cat),
+                                         'cohort "{}"'.format(cohort.replace(";", ","))])
+            )
+        )
+
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if args.gene_lengths:
+        gene_lengths = parse_gene_lengths(args.gene_lengths)
+    else:
+        gene_lengths = {}
+    converters = {"gtf": convert_to_gtf, 
+                  "saf": partial(convert_to_saf, annotation_type=args.annotation_type),
+                  "igc_medusa": partial(convert_medusa_to_gtf, gene_lengths=gene_lengths)}
+    annotation_lines = parse_igc_annotation(args.IGC_ANNOTATION)
+    converters[args.format](annotation_lines)


### PR DESCRIPTION
# Summarize read counts per annotation
This PR adds a step on top of the BBMap/Bowtie2 mapping steps to summarize read counts per annotated feature. It uses [featureCounts](http://bioinf.wehi.edu.au/featureCounts/) for the read count summaries, which uses annotations in GTF format. 

The featureCounts step is optional, and is triggered on whether the featureCounts annotation setting in `config.yaml` holds a value other than the empty string. 

## Not only GTF 
The way it is implemented, it is in fact possible to use also annotations in SAF (simple annotation format) thanks to support by `featureCounts`. To use SAF annotations instead of GTF, simply input the SAF annotation file as a parameter to the featureCounts annotation setting in `config.yaml`, and put the string `-F SAF` as an option in the featureCounts extra setting in `config.yaml`. 

