### PR TITLE
Use pathlib

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,12 @@ designed to allow some inclusion logic in the main Snakefile, so components can
 be turned on or off without too much trouble. Output should typically be in a
 subfolder inside the overall `outdir` folder. `outdir` is available as a string
 in all rule files, as it is defined in the main Snakefile based on the value
-set in `config.yaml`. 
+set in `config.yaml`.
+
+Declare paths to input, output and log files using the pathlib Path objects
+INPUTDIR, OUTDIR, and LOGDIR. Note that Snakemake is not yet fully pathlib
+compatible so convert Path objects to strings inside `expand` statements and
+log file declarations.
 
 Tools that require databases or other reference material to work can be
 confusing or annyoing to users of the workflow. To minimize the amount of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,18 +5,41 @@ We use the issue tracker in Github. Submit issues for things such as
 bug reports, feature requests, or general improvement discussion topics.
 
 ## Submitting changes
-The typical procedure to develop new features or fix bugs in StaG-mwc looks
-something like this:
+The main branch of StaG-mwc should always be stable and reliable. All
+development should be based on the develop branch. Please create new feature
+branches from the develop branch. The develop branch is then merged into the
+master branch when enough improvements have accrued. The typical procedure to
+develop new features or fix bugs in StaG-mwc looks something like this:
 
 1. Fork or clone the repository.
-2. Create a branch with a descriptive name based on your intended changes using
-   dashes to separate words, e.g. `branch-to-add-megahit-assembly-step`.
-3. Insert your code into the respective folders, i.e. scripts, rules and envs.
-   Define the entry point of the workflow in the Snakefile and the main
-   configuration in the config.yaml file.
+2. Checkout the develop branch and create a new feature branch from there.
+   Use a descriptive name and use dashes to separate words:
+   ```
+   git checkout develop
+   git checkout -b add-megahit-assembly-step
+   ```
+3. Write or modify code in the scripts, rules and envs folders. Define the
+   entry point of the workflow in the Snakefile and the main configuration in the
+   config.yaml file.
+4. If a new feature has been added, document it in the Sphinx documentation.
 4. Commit changes to your fork/clone.
-5. Create a pull request (PR) with some motivation behind the work you have
-   done and possibly some explanations for tricky bits.
+5. Create a pull request (PR) with some descriptions of the work you have
+   done and possibly some explanations for potentially tricky bits.
+6. When the feature is considered complete, we bump the version number and
+   merge the PR back to the develop branch.
+
+### Releases
+New releases are made whenever enough new features have accrued on the develop
+branch. Before creating a new release, ensure the following things have been
+taken care of:
+
+* All pending features that should be included in the upcoming release are
+  merged into the develop branch.
+* Double check that documentation is up-to-date for implemented features.
+* Check that the version number in the documentation matches the Snakefile.
+
+Then, merge the develop branch into master, squashing all commits, and tag
+the new release.
 
 
 ## Code organization

--- a/Snakefile
+++ b/Snakefile
@@ -1,24 +1,32 @@
 # vim: syntax=python expandtab
 #
-#                   StaG
-#   mwc - Metagenomic Workflow Collaboration
+#    StaG Metagenomic Workflow Collaboration
+#                 StaG-mwc
 #         Copyright (c) 2018 Authors
 #
-# Running snakemake -n in a clone of this repository should successfully
-# execute a test dry-run of the workflow.
+# Running snakemake --use-conda -n in a clone of this repository should
+# successfully execute a test dry run of the workflow.
 from pathlib import Path
 
 from snakemake.exceptions import WorkflowError
 from snakemake.utils import min_version
-min_version("4.8.1") # Don't know what version expand will be fixed in
+min_version("4.8.1")  # TODO: Bump version when Snakemake is pathlib compatible
+
+stag_version = "0.1.1-dev"
+print("="*60)
+print("StaG Metagenomic Workflow Collaboration".center(60))
+print("StaG-mwc".center(60))
+print(stag_version.center(60))
+print("="*60)
 
 configfile: "config.yaml"
-inputdir = Path(config["inputdir"])
-outdir = Path(config["outdir"])
-logdir = Path(config["logdir"])
+INPUTDIR = Path(config["inputdir"])
+OUTDIR = Path(config["outdir"])
+LOGDIR = Path(config["logdir"])
+DBDIR = Path(config["dbdir"])
 all_outputs = []
 
-SAMPLES = set(glob_wildcards(inputdir/config["input_fn_pattern"]).sample)
+SAMPLES = set(glob_wildcards(INPUTDIR/config["input_fn_pattern"]).sample)
 
 #############################
 # Pre-processing

--- a/Snakefile
+++ b/Snakefile
@@ -6,16 +6,16 @@
 #
 # Running snakemake -n in a clone of this repository should successfully
 # execute a test dry-run of the workflow.
+from pathlib import Path
+
 from snakemake.exceptions import WorkflowError
 
-from sys import exit
-import os.path
-
 configfile: "config.yaml"
-outdir = config["outdir"]
+inputdir = Path(config["inputdir"])
+outdir = Path(config["outdir"])
 all_outputs = []
 
-SAMPLES = set(glob_wildcards(config["inputdir"]+"/"+config["input_fn_pattern"]).sample)
+SAMPLES = set(glob_wildcards(inputdir/config["input_fn_pattern"]).sample)
 
 #############################
 # Pre-processing

--- a/Snakefile
+++ b/Snakefile
@@ -9,10 +9,13 @@
 from pathlib import Path
 
 from snakemake.exceptions import WorkflowError
+from snakemake.utils import min_version
+min_version("4.8.1") # Don't know what version expand will be fixed in
 
 configfile: "config.yaml"
 inputdir = Path(config["inputdir"])
 outdir = Path(config["outdir"])
+logdir = Path(config["logdir"])
 all_outputs = []
 
 SAMPLES = set(glob_wildcards(inputdir/config["input_fn_pattern"]).sample)

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,7 @@
 inputdir: "input"
 input_fn_pattern: "{sample}_R{readpair}.fastq.gz" 
 outdir: "output_dir"
+logdir: "output_dir/logs"
 dbdir: "databases"           # Databases will be downloaded to this dir, if requested
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,9 +56,9 @@ author = 'Fredrik Boulund, Lisa Olsson'
 # built documents.
 #
 # The short X.Y version.
-version = '0.1.0'
+version = '0.1.1'
 # The full version, including alpha/beta/rc tags.
-release = '0.1.0-dev'
+release = '0.1.1-dev'
 
 # reStructuredText prolog contains a string of reStructuredText that will be
 # included at the beginning of every source file that is read.

--- a/rules/antibiotic_resistance/megares.smk
+++ b/rules/antibiotic_resistance/megares.smk
@@ -1,19 +1,20 @@
 # Generic rules for detection of antibiotic resistance genes using MEGARes
+# TODO: Remove superfluous str conversions when Snakemake is pathlib compatible.
+from pathlib import Path
 from snakemake.exceptions import WorkflowError
-import os.path
 
 localrules:
     download_megares
 
-if not os.path.isdir(os.path.join(config["megares"]["db_path"], "ref")):
-    err_message = "No MEGARes database found at: '{}'!\n".format(config["megares"]["db_path"])
+megares_db_path = Path(config["megares"]["db_path"])
+if not Path(megares_db_path/"ref").exists():
+    err_message = "No MEGARes database found at: '{}'!\n".format(megares_db_path)
     err_message += "Specify the DB path in the megares section of config.yaml.\n"
-    err_message += "Run 'snakemake create_megares_index' to download and build a BBMap index in '{dbdir}/megares'\n".format(dbdir=config["dbdir"])
+    err_message += "Run 'snakemake create_megares_index' to download and build a BBMap index in '{dbdir}'\n".format(dbdir=DBDIR/"megares")
     err_message += "If you do not want to map reads against MEGARes for antibiotic resistance gene detection, set antibiotic_resistance: False in config.yaml"
     raise WorkflowError(err_message)
 
-megares_outputs = expand("{outdir}/megares/{sample}.{output_type}",
-        outdir=outdir,
+megares_outputs = expand(str(OUTDIR/"megares/{sample}.{output_type}"),
         sample=SAMPLES,
         output_type=("sam.gz", "mapped_reads.fq.gz", "mhist.txt", "covstats.txt", "rpkm.txt"))
 all_outputs.extend(megares_outputs)
@@ -21,46 +22,53 @@ all_outputs.extend(megares_outputs)
 rule download_megares:
     """Download MEGARes database."""
     output:
-        config["dbdir"]+"/megares/megares_annotations_v1.01.csv",
-        config["dbdir"]+"/megares/megares_database_v1.01.fasta",
-        config["dbdir"]+"/megares/megares_to_external_header_mappings_v1.01.tsv",
+        DBDIR/"megares/megares_annotations_v1.01.csv",
+        DBDIR/"megares/megares_database_v1.01.fasta",
+        DBDIR/"megares/megares_to_external_header_mappings_v1.01.tsv",
+    log:
+        str(LOGDIR/"megares/megares.download.log")
     shadow:
         "shallow"
     params:
-        dbdir=config["dbdir"]+"/megares"
+        dbdir=DBDIR/"megares"
     shell:
         """
         cd {params.dbdir}
         wget http://megares.meglab.org/download/megares_v1.01.zip \
+            > {log} \
         && \
         unzip megares_v1.01.zip \
+            >> {log} \
         && \
         mv megares_v1.01/* . \
         && \
-        rm -rfv megares_v1.01 megares_v1.01.zip
+        rm -rfv megares_v1.01 megares_v1.01.zip \
+            >> {log}
         """
 
 
 rule create_megares_index:
     """Create BBMap index for MEGARes."""
     input:
-        fasta=config["dbdir"]+"/megares/megares_database_v1.01.fasta"
+        fasta=DBDIR/"megares/megares_database_v1.01.fasta"
     output:
-        config["dbdir"]+"/megares/ref/genome/1/chr1.chrom.gz",
-        config["dbdir"]+"/megares/ref/genome/1/info.txt",
-        config["dbdir"]+"/megares/ref/genome/1/scaffolds.txt.gz",
-        config["dbdir"]+"/megares/ref/genome/1/summary.txt",
-        config["dbdir"]+"/megares/ref/index/1/chr1_index_k13_c8_b1.block",
-        config["dbdir"]+"/megares/ref/index/1/chr1_index_k13_c8_b1.block2.gz",
+        DBDIR/"megares/ref/genome/1/chr1.chrom.gz",
+        DBDIR/"megares/ref/genome/1/info.txt",
+        DBDIR/"megares/ref/genome/1/scaffolds.txt.gz",
+        DBDIR/"megares/ref/genome/1/summary.txt",
+        DBDIR/"megares/ref/index/1/chr1_index_k13_c8_b1.block",
+        DBDIR/"megares/ref/index/1/chr1_index_k13_c8_b1.block2.gz",
+    log:
+        str(LOGDIR/"megares/megares.bbmap_index.log")
     shadow:
         "shallow"
     conda:
         "../../envs/stag-mwc.yaml"
     params:
-        dbdir=config["dbdir"]+"/megares"
+        dbdir=DBDIR/"megares"
     shell:
         """
-        bbmap.sh ref={input} path={params.dbdir}
+        bbmap.sh ref={input} path={params.dbdir} > {log}
         """
 
 
@@ -68,17 +76,17 @@ megares_config = config["megares"]
 rule bbmap_to_megares:
     """BBMap to MEGARes."""
     input:
-        read1=config["outdir"]+"/filtered_human/{sample}_R1.filtered_human.fq.gz",
-        read2=config["outdir"]+"/filtered_human/{sample}_R2.filtered_human.fq.gz",
+        read1=OUTDIR/"filtered_human/{sample}_R1.filtered_human.fq.gz",
+        read2=OUTDIR/"filtered_human/{sample}_R2.filtered_human.fq.gz",
     output:
-        sam=config["outdir"]+"/megares/{sample}.sam.gz",
-        mapped_reads=config["outdir"]+"/megares/{sample}.mapped_reads.fq.gz",
-        covstats=config["outdir"]+"/megares/{sample}.covstats.txt",
-        rpkm=config["outdir"]+"/megares/{sample}.rpkm.txt",
-        mhist=config["outdir"]+"/megares/{sample}.mhist.txt",
+        sam=OUTDIR/"megares/{sample}.sam.gz",
+        mapped_reads=OUTDIR/"megares/{sample}.mapped_reads.fq.gz",
+        covstats=OUTDIR/"megares/{sample}.covstats.txt",
+        rpkm=OUTDIR/"megares/{sample}.rpkm.txt",
+        mhist=OUTDIR/"megares/{sample}.mhist.txt",
     log:
-        stdout=config["outdir"]+"/logs/megares/{sample}.bbmap.stdout.log",
-        stderr=config["outdir"]+"/logs/megares/{sample}.bbmap.statsfile.txt"
+        stdout=str(LOGDIR/"megares/{sample}.bbmap.stdout.log"),
+        stderr=str(LOGDIR/"megares/{sample}.bbmap.statsfile.txt"),
     shadow:
         "shallow"
     conda:

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -1,50 +1,48 @@
 # Generic rules for alignment of reads to a reference database using Bowtie2
+# TODO: Remove superfluous str conversions when Snakemake is pathlib compatible.
+from pathlib import Path
+
 from snakemake.exceptions import WorkflowError
-import os.path
 
 localrules:
     bowtie2_counts_table
     bowtie2_featureCounts
 
 bt2_db_extensions = (".1.bt2", ".1.bt2l")
-if not any([os.path.isfile(config["bowtie2"]["db_prefix"]+ext) for ext in bt2_db_extensions]):
+if not any([Path(config["bowtie2"]["db_prefix"]).with_suffix(ext) for ext in bt2_db_extensions]):
     err_message = "Bowtie2 index not found at: '{}'\n".format(config["bowtie2"]["db_prefix"])
     err_message += "Check path in config setting 'bowtie2:db_prefix'.\n"
     err_message += "If you want to skip mapping with bowtie2, set mappers:bowtie2:False in config.yaml."
     raise WorkflowError(err_message)
-bt2_db_name = os.path.basename(config["bowtie2"]["db_prefix"])
+bt2_db_name = Path(config["bowtie2"]["db_prefix"]).name
 
 # Add final output files from this module to 'all_outputs' from the main
 # Snakefile scope. SAMPLES is also from the main Snakefile scope.
-bowtie2_alignments = expand("{outdir}/bowtie2/{db_name}/{sample}.bam",
-        outdir=config["outdir"],
+bowtie2_alignments = expand(str(OUTDIR/"bowtie2/{db_name}/{sample}.bam"),
         sample=SAMPLES,
         db_name=bt2_db_name)
-bowtie2_stats = expand("{outdir}/bowtie2/{db_name}/{sample}.{stats}.txt",
-        outdir=config["outdir"],
+bowtie2_stats = expand(str(OUTDIR/"bowtie2/{db_name}/{sample}.{stats}.txt"),
         sample=SAMPLES,
         stats=["covstats", "rpkm"],
         db_name=bt2_db_name)
-counts_table = expand("{outdir}/bowtie2/{db_name}/all_samples.counts_table.tab",
-        outdir=config["outdir"],
+counts_table = expand(str(OUTDIR/"bowtie2/{db_name}/all_samples.counts_table.tab"),
         db_name=bt2_db_name,
         sample=SAMPLES)
-featureCounts = expand("{outdir}/bowtie2/{db_name}/all_samples.featureCounts{output_type}",
-        outdir=config["outdir"],
+featureCounts = expand(str(OUTDIR/"bowtie2/{db_name}/all_samples.featureCounts{output_type}"),
         db_name=bt2_db_name,
         sample=SAMPLES,
         output_type=["", ".summary", ".table.tsv"])
 all_outputs.extend(bowtie2_alignments)
 all_outputs.extend(bowtie2_stats)
 if config["bowtie2"]["counts_table"]["annotations"]:
-    if not os.path.isfile(config["bowtie2"]["counts_table"]["annotations"]):
+    if not Path(config["bowtie2"]["counts_table"]["annotations"]).exists():
         err_message = "Bowtie2 counts_table annotations not found at: '{}'\n".format(config["bowtie2"]["counts_table"]["annotations"])
         err_message += "Check path in config setting 'bowtie2:counts_table:annotations'.\n"
         err_message += "If you want to skip the counts table summary for Bowtie2, set bowtie2:counts_table:annotations to '' in config.yaml."
         raise WorkflowError(err_message)
     all_outputs.extend(counts_table)
 if config["bowtie2"]["featureCounts"]["annotations"]:
-    if not os.path.isfile(config["bowtie2"]["featureCounts"]["annotations"]):
+    if not Path(config["bowtie2"]["featureCounts"]["annotations"]).exists():
         err_message = "Bowtie2 featureCounts annotations not found at: '{}'\n".format(config["bowtie2"]["featureCounts"]["annotations"])
         err_message += "Check path in config setting 'bowtie2:featureCounts:annotations'.\n"
         err_message += "If you want to skip mapping with Bowtie2, set mappers:bowtie2:False in config.yaml."
@@ -54,12 +52,12 @@ if config["bowtie2"]["featureCounts"]["annotations"]:
 rule bowtie2:
     """Align reads using Bowtie2."""
     input:
-        sample=[config["outdir"]+"/filtered_human/{sample}_R1.filtered_human.fq.gz",
-                config["outdir"]+"/filtered_human/{sample}_R2.filtered_human.fq.gz"]
+        sample=[OUTDIR/"filtered_human/{sample}_R1.filtered_human.fq.gz",
+                OUTDIR/"filtered_human/{sample}_R2.filtered_human.fq.gz"]
     output:
-        config["outdir"]+"/bowtie2/{db_name}/{{sample}}.bam".format(db_name=bt2_db_name)
+        OUTDIR/"bowtie2/{db_name}/{{sample}}.bam".format(db_name=bt2_db_name)
     log:
-        config["outdir"]+"/logs/bowtie2/{db_name}/{{sample}}.log".format(db_name=bt2_db_name)
+        str(LOGDIR/"bowtie2/{db_name}/{{sample}}.log".format(db_name=bt2_db_name))
     params:
         index=config["bowtie2"]["db_prefix"],
         extra=config["bowtie2"]["extra"],
@@ -72,12 +70,12 @@ rule bowtie2:
 rule bowtie2_mapping_stats:
     """Summarize bowtie2 mapping statistics."""
     input:
-        bam=config["outdir"]+"/bowtie2/{dbname}/{{sample}}.bam".format(dbname=bt2_db_name)
+        bam=OUTDIR/"bowtie2/{dbname}/{{sample}}.bam".format(dbname=bt2_db_name)
     output:
-        covstats=config["outdir"]+"/bowtie2/{dbname}/{{sample}}.covstats.txt".format(dbname=bt2_db_name),
-        rpkm=config["outdir"]+"/bowtie2/{dbname}/{{sample}}.rpkm.txt".format(dbname=bt2_db_name)
+        covstats=OUTDIR/"bowtie2/{dbname}/{{sample}}.covstats.txt".format(dbname=bt2_db_name),
+        rpkm=OUTDIR/"bowtie2/{dbname}/{{sample}}.rpkm.txt".format(dbname=bt2_db_name)
     log:
-        config["outdir"]+"/logs/bowtie2/{dbname}/{{sample}}.pileup.log".format(dbname=bt2_db_name)
+        str(LOGDIR/"bowtie2/{dbname}/{{sample}}.pileup.log".format(dbname=bt2_db_name))
     shadow:
         "shallow"
     conda:
@@ -93,13 +91,13 @@ rule bowtie2_mapping_stats:
 
 rule bowtie2_counts_table:
     input:
-        rpkms=expand(config["outdir"]+"/bowtie2/{dbname}/{sample}.rpkm.txt",
+        rpkms=expand(str(OUTDIR/"bowtie2/{dbname}/{sample}.rpkm.txt"),
                 dbname=bt2_db_name,
                 sample=SAMPLES)
     output:
-        counts=config["outdir"]+"/bowtie2/{dbname}/all_samples.counts_table.tab".format(dbname=bt2_db_name),
+        counts=OUTDIR/"bowtie2/{dbname}/all_samples.counts_table.tab".format(dbname=bt2_db_name),
     log:
-        config["outdir"]+"/logs/bowtie2/{dbname}/all_samples.counts_table.log".format(dbname=bt2_db_name)
+        str(LOGDIR/"bowtie2/{dbname}/all_samples.counts_table.log".format(dbname=bt2_db_name))
     shadow:
         "shallow"
     conda:
@@ -121,15 +119,15 @@ rule bowtie2_counts_table:
 fc_config = config["bowtie2"]["featureCounts"]
 rule bowtie2_featureCounts:
     input:
-        bams=expand(config["outdir"]+"/bowtie2/{dbname}/{sample}.bam",
+        bams=expand(str(OUTDIR/"bowtie2/{dbname}/{sample}.bam"),
                 dbname=bt2_db_name,
                 sample=SAMPLES)
     output:
-        counts=config["outdir"]+"/bowtie2/{dbname}/all_samples.featureCounts".format(dbname=bt2_db_name),
-        counts_table=config["outdir"]+"/bowtie2/{dbname}/all_samples.featureCounts.table.tsv".format(dbname=bt2_db_name),
-        summary=config["outdir"]+"/bowtie2/{dbname}/all_samples.featureCounts.summary".format(dbname=bt2_db_name),
+        counts=OUTDIR/"bowtie2/{dbname}/all_samples.featureCounts".format(dbname=bt2_db_name),
+        counts_table=OUTDIR/"bowtie2/{dbname}/all_samples.featureCounts.table.tsv".format(dbname=bt2_db_name),
+        summary=OUTDIR/"bowtie2/{dbname}/all_samples.featureCounts.summary".format(dbname=bt2_db_name),
     log:
-        config["outdir"]+"/logs/bowtie2/{dbname}/all_samples.featureCounts.log".format(dbname=bt2_db_name)
+        str(LOGDIR/"bowtie2/{dbname}/all_samples.featureCounts.log".format(dbname=bt2_db_name))
     shadow:
         "shallow"
     conda:

--- a/rules/preproc/bbcountunique.smk
+++ b/rules/preproc/bbcountunique.smk
@@ -1,11 +1,10 @@
 # vim: syntax=python expandtab
 # Assess sequencing depth of sample using BBCountUnique from the BBMap suite.
-import os.path
+# TODO: Remove superfluous str conversions when Snakemake is pathlib compatible.
 
 # Add final output files from this module to 'all_outputs' from
 # the main Snakefile scope. SAMPLES is also from the main Snakefile scope.
-bcu_output = expand("{outdir}/bbcountunique/{sample}.{output_type}",
-        outdir=config["outdir"],
+bcu_output = expand(str(OUTDIR/"bbcountunique/{sample}.{output_type}"),
         sample=SAMPLES,
         output_type=["bbcountunique.txt", "bbcountunique.pdf"])
 all_outputs.extend(bcu_output)
@@ -13,13 +12,13 @@ all_outputs.extend(bcu_output)
 rule bbcountunique:
     """Assess sequencing depth using BBCountUnique."""
     input:
-        os.path.join(config["inputdir"], config["input_fn_pattern"]).format(sample="{sample}", readpair="1")
+        INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="1")
     output:
-        txt=config["outdir"]+"/bbcountunique/{sample}.bbcountunique.txt",
-        pdf=config["outdir"]+"/bbcountunique/{sample}.bbcountunique.pdf",
+        txt=OUTDIR/"bbcountunique/{sample}.bbcountunique.txt",
+        pdf=OUTDIR/"bbcountunique/{sample}.bbcountunique.pdf",
     log:
-        stdout=config["outdir"]+"/logs/bbcountunique/{sample}.bbcountunique.stdout.log",
-        stderr=config["outdir"]+"/logs/bbcountunique/{sample}.bbcountunique.stderr.log",
+        stdout=str(LOGDIR/"bbcountunique/{sample}.bbcountunique.stdout.log"),
+        stderr=str(LOGDIR/"bbcountunique/{sample}.bbcountunique.stderr.log"),
     shadow: 
         "shallow"
     threads:

--- a/rules/preproc/read_quality.smk
+++ b/rules/preproc/read_quality.smk
@@ -1,13 +1,15 @@
 # vim: syntax=python expandtab
 # MWC read pre-processing rules
+#TODO: Remove superfluous str conversions of paths in expand and log statements
+#      when Snakemake is pathlib compatible.
 
 # Add final output files from this module to 'all_outputs' from
 # the main Snakefile scope. SAMPLES is also from the main Snakefile scope.
-fastqc_output = expand(outdir/"fastqc/{sample}_R{readpair}_fastqc.{ext}",
+fastqc_output = expand(str(OUTDIR/"fastqc/{sample}_R{readpair}_fastqc.{ext}"),
         sample=SAMPLES,
         readpair=[1, 2],
         ext=["zip", "html"])
-trimmed_qa = expand(outdir/"trimmed_qa/{sample}_R{readpair}.trimmed_qa.fq.gz",
+trimmed_qa = expand(str(OUTDIR/"trimmed_qa/{sample}_R{readpair}.trimmed_qa.fq.gz"),
         sample=SAMPLES,
         readpair=[1, 2])
 all_outputs.extend(fastqc_output)
@@ -15,10 +17,12 @@ all_outputs.extend(trimmed_qa)
 
 rule fastqc:
     input:
-        inputdir/config["input_fn_pattern"]
+        INPUTDIR/config["input_fn_pattern"]
     output:
-        html=outdir/"fastqc/{sample}_R{readpair}_fastqc.html",
-        zip=outdir/"fastqc/{sample}_R{readpair}_fastqc.zip",
+        html=OUTDIR/"fastqc/{sample}_R{readpair}_fastqc.html",
+        zip=OUTDIR/"fastqc/{sample}_R{readpair}_fastqc.zip",
+    log:
+        str(LOGDIR/"fastqc/{sample}_R{readpair}_fastq.log")
     shadow: 
         "shallow"
     wrapper:
@@ -28,14 +32,14 @@ rule fastqc:
 bbduk_config = config["bbduk"]
 rule trim_adapters_quality:
     input:
-        read1=inputdir/config["input_fn_pattern"].format(sample="{sample}", readpair="1"),
-        read2=inputdir/config["input_fn_pattern"].format(sample="{sample}", readpair="2")
+        read1=INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="1"),
+        read2=INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="2")
     output:
-        read1=outdir/"trimmed_qa/{sample}_R1.trimmed_qa.fq.gz",
-        read2=outdir/"trimmed_qa/{sample}_R2.trimmed_qa.fq.gz",
+        read1=OUTDIR/"trimmed_qa/{sample}_R1.trimmed_qa.fq.gz",
+        read2=OUTDIR/"trimmed_qa/{sample}_R2.trimmed_qa.fq.gz",
     log:
-        stdout=logdir/"bbduk/{sample}.stdout.log",
-        stderr=logdir/"bbduk/{sample}.stderr.log",
+        stdout=str(LOGDIR/"bbduk/{sample}.stdout.log"),
+        stderr=str(LOGDIR/"bbduk/{sample}.stderr.log"),
     shadow:
         "shallow"
     conda:

--- a/rules/preproc/read_quality.smk
+++ b/rules/preproc/read_quality.smk
@@ -1,27 +1,24 @@
 # vim: syntax=python expandtab
 # MWC read pre-processing rules
-import os.path
 
 # Add final output files from this module to 'all_outputs' from
 # the main Snakefile scope. SAMPLES is also from the main Snakefile scope.
-fastqc_output = expand("{outdir}/fastqc/{sample}_R{readpair}_fastqc.{ext}",
-        outdir=config["outdir"],
+fastqc_output = expand(outdir/"fastqc/{sample}_R{readpair}_fastqc.{ext}",
         sample=SAMPLES,
-        readpair=[1,2],
+        readpair=[1, 2],
         ext=["zip", "html"])
-trimmed_qa = expand("{outdir}/trimmed_qa/{sample}_R{readpair}.trimmed_qa.fq.gz",
-        outdir=config["outdir"],
+trimmed_qa = expand(outdir/"trimmed_qa/{sample}_R{readpair}.trimmed_qa.fq.gz",
         sample=SAMPLES,
-        readpair=[1,2])
+        readpair=[1, 2])
 all_outputs.extend(fastqc_output)
 all_outputs.extend(trimmed_qa)
 
 rule fastqc:
     input:
-        os.path.join(config["inputdir"], config["input_fn_pattern"])
+        inputdir/config["input_fn_pattern"]
     output:
-        html=config["outdir"]+"/fastqc/{sample}_R{readpair}_fastqc.html",
-        zip=config["outdir"]+"/fastqc/{sample}_R{readpair}_fastqc.zip",
+        html=outdir/"fastqc/{sample}_R{readpair}_fastqc.html",
+        zip=outdir/"fastqc/{sample}_R{readpair}_fastqc.zip",
     shadow: 
         "shallow"
     wrapper:
@@ -31,14 +28,14 @@ rule fastqc:
 bbduk_config = config["bbduk"]
 rule trim_adapters_quality:
     input:
-        read1=os.path.join(config["inputdir"], config["input_fn_pattern"]).format(sample="{sample}", readpair="1"),
-        read2=os.path.join(config["inputdir"], config["input_fn_pattern"]).format(sample="{sample}", readpair="2")
+        read1=inputdir/config["input_fn_pattern"].format(sample="{sample}", readpair="1"),
+        read2=inputdir/config["input_fn_pattern"].format(sample="{sample}", readpair="2")
     output:
-        read1=config["outdir"]+"/trimmed_qa/{sample}_R1.trimmed_qa.fq.gz",
-        read2=config["outdir"]+"/trimmed_qa/{sample}_R2.trimmed_qa.fq.gz",
+        read1=outdir/"trimmed_qa/{sample}_R1.trimmed_qa.fq.gz",
+        read2=outdir/"trimmed_qa/{sample}_R2.trimmed_qa.fq.gz",
     log:
-        stdout=config["outdir"]+"/logs/bbduk/{sample}.stdout.log",
-        stderr=config["outdir"]+"/logs/bbduk/{sample}.stderr.log",
+        stdout=logdir/"bbduk/{sample}.stdout.log",
+        stderr=logdir/"bbduk/{sample}.stderr.log",
     shadow:
         "shallow"
     conda:

--- a/rules/taxonomic_profiling/centrifuge.smk
+++ b/rules/taxonomic_profiling/centrifuge.smk
@@ -1,34 +1,35 @@
 # vim: syntax=python expandtab
 # Taxonomic classification of metagenomic reads using Centrifuge
+# TODO: Remove superfluous str conversions when Snakemake is pathlib compatible.
+from pathlib import Path
+
 from snakemake.exceptions import WorkflowError
-import os.path
 
 localrules:
     download_centrifuge_database
 
 centrifuge_db_ext = ".1.cf"
-if not os.path.isfile(config["centrifuge"]["db_prefix"]+centrifuge_db_ext):
+if not Path(config["centrifuge"]["db_prefix"]).with_suffix(centrifuge_db_ext).exists():
     err_message = "No Centrifuge database found at: '{}'!\n".format(config["centrifuge"]["db_prefix"])
     err_message += "Specify Centrifuge database prefix in the Centrifuge section of config.yaml.\n"
-    err_message += "Run 'snakemake download_centrifuge_database' to download a copy into '{dbdir}/centrifuge'\n".format(dbdir=config["dbdir"])
+    err_message += "Run 'snakemake download_centrifuge_database' to download a copy into '{dbdir}'\n".format(dbdir=DBDIR/"centrifuge")
     err_message += "If you do not want to run Centrifuge for taxonomic profiling, set centrifuge: False in config.yaml"
     raise WorkflowError(err_message)
 
 # Add final output files from this module to 'all_outputs' from the main
 # Snakefile scope. SAMPLES is also from the main Snakefile scope.
-centrifuge = expand("{outdir}/centrifuge/{sample}.{output_type}.tsv",
-        outdir=config["outdir"],
+centrifuge = expand(str(OUTDIR/"centrifuge/{sample}.{output_type}.tsv"),
         sample=SAMPLES,
         output_type=("centrifuge", "centrifuge_report"))
 all_outputs.extend(centrifuge)
 
 rule download_centrifuge_database:
     output:
-        db=[config["dbdir"]+"/centrifuge/p+h+v.{n}.cf".format(n=num) for num in (1,2,3)]
+        db=[DBDIR/"centrifuge/p+h+v.{n}.cf".format(n=num) for num in (1,2,3)]
     shadow:
         "shallow"
     params:
-        dbdir=config["dbdir"]+"/centrifuge"
+        dbdir=DBDIR/"centrifuge"
     shell:
         """
         cd {params.dbdir}
@@ -43,13 +44,13 @@ rule download_centrifuge_database:
 cf_config = config["centrifuge"]
 rule centrifuge:
     input:
-        read1=config["outdir"]+"/filtered_human/{sample}_R1.filtered_human.fq.gz",
-        read2=config["outdir"]+"/filtered_human/{sample}_R2.filtered_human.fq.gz",
+        read1=OUTDIR/"filtered_human/{sample}_R1.filtered_human.fq.gz",
+        read2=OUTDIR/"filtered_human/{sample}_R2.filtered_human.fq.gz",
     output:
-        classifications=config["outdir"]+"/centrifuge/{sample}.centrifuge.tsv",
-        report=config["outdir"]+"/centrifuge/{sample}.centrifuge_report.tsv",
+        classifications=OUTDIR/"centrifuge/{sample}.centrifuge.tsv",
+        report=OUTDIR/"centrifuge/{sample}.centrifuge_report.tsv",
     log:
-        config["outdir"]+"/logs/centrifuge/{sample}.centrifuge.log"
+        str(LOGDIR/"centrifuge/{sample}.centrifuge.log")
     shadow: 
         "shallow"
     conda:


### PR DESCRIPTION
Convert all input, outputs, and log statements to use pathlib instead of working with paths as strings.

A few minor annoyances, however; Snakemake support for pathlib is currently not complete, most promimently, expand statements and log file declarations cannot use pathlib objects at the moment, so they are explicitly converted to strings in the rule files. I plan to change this when Snakemake becomes fully compatible further on. 

I also introduce the develop branch in this PR, intending that the master branch of the repo should be considered stable and will only receive commits when enough new features have been added to the develop branch. 