### PR TITLE
Add HUMAnN2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 *
-!config.yaml
 !cluster_configs
 !cluster_configs/*
 !cluster_configs/*/*
+!config.yaml
 !docs
 !docs/Makefile
 !docs/source
@@ -23,6 +23,8 @@
 !rules/*
 !rules/antibiotic_resistance
 !rules/antibiotic_resistance/*
+!rules/functional_profiling
+!rules/functional_profiling/*
 !rules/mappers
 !rules/mappers/*
 !rules/preproc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ situations.
 - Added CHANGELOG.md
 - New functionality to run mappers several times against different databases,
   based on a list of reference databases to map against in the config file.
-- Functional profiling using HUMAnN2. Can use pre-existing output from the
-  MetaPhlAn2 steps, if available in the output dir structure from a previous run.
+- Functional profiling using HUMAnN2. Will automatically run all
+  MetaPhlAn2-associated rules to produce taxonomic profiles for use in HUMAnN2.
 
 ### Changed
 - Substantial improvements to Rackham Slurm profile, focusing on better Slurm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ situations.
 - Added CHANGELOG.md
 - New functionality to run mappers several times against different databases,
   based on a list of reference databases to map against in the config file.
+- Functional profiling using HUMAnN2. Can use pre-existing output from the
+  MetaPhlAn2 steps, if available in the output dir structure from a previous run.
 
 ### Changed
 - Substantial improvements to Rackham Slurm profile, focusing on better Slurm
@@ -37,7 +39,7 @@ situations.
 - Started using Python's pathlib module for Snakefile rule input, output, and
   log file declarations. Some unsightly explicit string conversions still remain,
   due to Snakemake not being fully compatible with pathlib (yet).
-- Add details about branchin structure/strategy to CONTRIBUTING.md
+- Add details about branching structure/strategy to CONTRIBUTING.md
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # StaG Metagenomic Workflow Collaboration (mwc)
 
-[![Snakemake](https://img.shields.io/badge/snakemake-≥3.12.0-brightgreen.svg)](https://snakemake.bitbucket.io)
-[![Build Status](https://travis-ci.org/snakemake-workflows/mwc.svg?branch=master)](https://travis-ci.org/snakemake-workflows/mwc)
+[![Snakemake](https://img.shields.io/badge/snakemake-≥4.8.1-brightgreen.svg)](https://snakemake.bitbucket.io)
+<!--[![Build Status](https://travis-ci.org/snakemake-workflows/mwc.svg?branch=master)](https://travis-ci.org/snakemake-workflows/mwc) -->
 ![StaG mwc logo](docs/source/img/stag_head_text.png "StaG mwc")
 
 This repo contains the code for a Snakemake workflow of the StaG Metagenomic

--- a/Snakefile
+++ b/Snakefile
@@ -10,9 +10,9 @@ from pathlib import Path
 
 from snakemake.exceptions import WorkflowError
 from snakemake.utils import min_version
-min_version("4.8.1")  # TODO: Bump version when Snakemake is pathlib compatible
+min_version("4.8.1")  # TODO: Bump version requirement when Snakemake is pathlib compatible
 
-stag_version = "0.1.2-dev"
+stag_version = "0.2.0-dev"
 print("="*60)
 print("StaG Metagenomic Workflow Collaboration".center(60))
 print("StaG-mwc".center(60))
@@ -66,6 +66,12 @@ if config["taxonomic_profile"]["kaiju"]:
 
 if config["taxonomic_profile"]["metaphlan2"]:
     include: "rules/taxonomic_profiling/metaphlan2.smk"
+
+#############################
+# Functional profiling
+#############################
+if config["functional_profile"]["humann2"]:
+    include: "rules/functional_profiling/humann2.smk"
 
 #############################
 # Antibiotic resistance

--- a/cluster_configs/rackham/rackham.yaml
+++ b/cluster_configs/rackham/rackham.yaml
@@ -62,8 +62,12 @@ metaphlan2:
     n: 4
     time: "01:30:00"
 
-
-
+#############################
+# Functional profiling
+#############################
+humann2:
+    n: 8
+    time: "03:00:00"
 
 #############################
 # Antibiotic resistance

--- a/config.yaml
+++ b/config.yaml
@@ -33,6 +33,8 @@ taxonomic_profile:
     centrifuge: False
     kaiju: False
     metaphlan2: False
+functional_profile:
+    humann2: False
 antibiotic_resistance: False
 
 
@@ -114,6 +116,18 @@ metaphlan2:
     d: "braycurtis"          # Heatmap: Distance function for samples.
     f: "correlation"         # Heatmap: Distance function for microbes.
     c: "jet"                 # Heatmap: Colormap, default is "jet"
+
+
+#########################
+# Functional profiling
+#########################
+humann2:
+    nucleotide_db: ""        # [Required] Path to ChocoPhlAn DB directory
+    protein_db: ""           # [Required] Path to protein database (typically UniRef90)
+    mpa_pkl: ""              # [Required] Path to MetaPhlAn2 pickle file: mpa_v20_m200.pkl
+    mpa_bt2_db_prefix: ""    # [Required] Path to MetaPhlAn2 Bowtie2 index prefix: /path/to/mpa_v20_m200 (no file extension)
+    norm_method: "relab"     # Normalization method (HUMAnN2 default is "cpm")
+    norm_mode: "community"   # Normalization mode, "community" or "levelwise"
 
 
 #########################

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -291,6 +291,10 @@ Outputs three files per sample, plus three summaries for all samples::
     all_samples.humann2_pathcoverage.tsv
     all_samples.humann2_pathabundances.tsv
 
+Note that HUMAnN2 uses the taxonomic profiles produced by MetaPhlAn2, so all
+MetaPhlAn2-associated steps are run regardless of whether it is actually
+enabled in ``config.yaml`` or not.
+
 
 Antibiotic resistance
 *********************

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -7,6 +7,7 @@
 .. _MEGARes: http://megares.meglab.org/
 .. _MetaPhlAn2: https://bitbucket.org/biobakery/metaphlan2/
 .. _featureCounts: http://bioinf.wehi.edu.au/featureCounts/
+.. _HUMAnN2: https://bitbucket.org/biobakery/humann2/
 
 Modules
 =======
@@ -269,6 +270,26 @@ Outputs three files per sample, plus three summaries for all samples::
 
 The file called ``all_samples.metaphlan2.pdf`` contains a standard MetaPhlAn2
 clustered heatmap plot containing all samples.
+
+
+Functional profiling
+**************
+
+HUMAnN2
+----------
+:Tool: `HUMAnN2`_
+:Output folder: ``humann2``
+
+Run `HUMAnN2`_ on the trimmed and filtered reads to produce a functional profile.
+Outputs three files per sample, plus three summaries for all samples::
+
+    <sample>.genefamilies.tsv
+    <sample>.pathcoverage.tsv
+    <sample>.pathabundances.tsv
+    
+    all_samples.humann2_genefamilies.tsv
+    all_samples.humann2_pathcoverage.tsv
+    all_samples.humann2_pathabundances.tsv
 
 
 Antibiotic resistance

--- a/envs/biobakery.yaml
+++ b/envs/biobakery.yaml
@@ -1,8 +1,8 @@
-name: stag-mwc-metaphlan2
+name: stag-mwc-biobakery
 channels:
     - bioconda
     - conda-forge
     - defaults
 dependencies:
-    - metaphlan2 =2.6.0
+    - humann2 =0.11.1
     - krona =2.7

--- a/envs/stag-mwc.yaml
+++ b/envs/stag-mwc.yaml
@@ -5,7 +5,7 @@ channels:
     - defaults
 dependencies:
     - python =3.5
-    - bbmap =37.90
+    - bbmap =37.99
     - centrifuge =1.0.3
     - kaiju =1.6.2
     - krona =2.7

--- a/rules/functional_profiling/humann2.smk
+++ b/rules/functional_profiling/humann2.smk
@@ -1,0 +1,204 @@
+# vim: syntax=python expandtab
+# Functional profiling of metagenomic reads using HUMAnN2
+# TODO: Remove superfluous str conversions when Snakemake is pathlib compatible.
+from pathlib import Path
+
+from snakemake.exceptions import WorkflowError
+
+localrules:
+    download_humann2_databases,
+    normalize_humann2_tables,
+    join_humann2_tables,
+
+h_config = config["humann2"]
+if not any([Path(h_config["nucleotide_db"]).exists(),
+            Path(h_config["protein_db"]).exists()]):
+    err_message = "Could not find HUMAnN2 nucleotide and protein databases at: '{}', '{}'!\n".format(h_config["nucleotide_db"], h_config["protein_db"])
+    err_message += "Specify relevant paths in the humann2 section of config.yaml.\n"
+    err_message += "Run 'snakemake download_humann2_databases' to download and build the default ChocoPhlAn and UniRef90 databases in '{dbdir}'\n".format(dbdir=DBDIR/"humann2")
+    err_message += "If you do not want to run HUMAnN2 for functional profiling, set functional_profile:humann2: False in config.yaml"
+    raise WorkflowError(err_message)
+bt2_db_ext = ".1.bt2"
+if not any([Path(h_config["mpa_pkl"]).exists(),
+            Path(h_config["mpa_bt2_db_prefix"]).with_suffix(bt2_db_ext).exists()]):
+    err_message = "No MetaPhlAn2 pickle or database found at: '{}', '{}'!\n".format(h_config["mpa_pkl"], h_config["mpa_bt2_db_prefix"])
+    err_message += "Specify relevant paths in the humann2 section of config.yaml.\n"
+    err_message += "Run 'snakemake build_metaphlan2_index' to download and build the default mpa_v20_m200 database in '{dbdir}'\n".format(dbdir=DBDIR/"metaphlan2")
+    err_message += "If you do not want to run HUMAnN2 for functional profiling, set functional_profile:humann2: False in config.yaml"
+    raise WorkflowError(err_message)
+
+# Add HUMAnN2 output files to 'all_outputs' from the main Snakefile scope.
+# SAMPLES is also from the main Snakefile scope.
+humann2_outputs = expand(str(OUTDIR/"humann2/{sample}_{output_type}.tsv"),
+        sample=SAMPLES,
+        output_type=("genefamilies", "pathcoverage", "pathabundance",
+                     "genefamilies_{method}".format(method=h_config["norm_method"])))
+merged_humann2_tables = expand(str(OUTDIR/"humann2/all_samples.humann2_{output_type}.tsv"),
+        output_type=("genefamilies", "pathcoverage", "pathabundance"))
+all_outputs.extend(humann2_outputs)
+all_outputs.extend(merged_humann2_tables)
+
+
+rule download_humann2_databases:
+    """Download ChocoPhlAn and UniRef90 (diamond)"""
+    output:
+        DBDIR/"humann2/chocophlan",
+        DBDIR/"humann2/uniref",
+    log:
+        str(LOGDIR/"humann2/database_download.log")
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/biobakery.yaml"
+    params:
+        dbdir=config["dbdir"]+"/humann2"
+    shell:
+        """
+        humann2_databases --download chocophlan full {params.dbdir} > {log}
+        humann2_databases --download uniref uniref90_diamond {params.dbdir} >> {log}
+        """
+
+
+def existing_mpa_output(wildcards, mpa_outdir=OUTDIR/"metaphlan2"):
+    """Return humann2 argument string for including MetaPhlAn2 profile if such
+    a profile already exists for the sample.
+    """
+    mpa_profile = mpa_outdir/"{sample}.metaphlan2.txt".format(sample=wildcards.sample)
+    if mpa_profile.exists():
+        return "--taxonomic-profile " + str(mpa_profile)
+    else:
+        return ""
+    return sample_mpa_output.exists()
+
+
+rule humann2:
+    """Functional profiling using HUMAnN2."""
+    input:
+        read1=OUTDIR/"filtered_human/{sample}_R1.filtered_human.fq.gz",
+        read2=OUTDIR/"filtered_human/{sample}_R2.filtered_human.fq.gz",
+    output:
+        OUTDIR/"humann2/{sample}_genefamilies.tsv",
+        OUTDIR/"humann2/{sample}_pathcoverage.tsv",
+        OUTDIR/"humann2/{sample}_pathabundance.tsv",
+    log:
+        stdout=str(LOGDIR/"humann2/{sample}.humann2.stdout.log"),
+        stderr=str(LOGDIR/"humann2/{sample}.humann2.stderr.log"),
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/biobakery.yaml"
+    threads:
+        8
+    params:
+        outdir=OUTDIR/"humann2",
+        nucleotide_db=h_config["nucleotide_db"],
+        protein_db=h_config["protein_db"],
+        taxonomic_profile=existing_mpa_output,
+        mpa_pkl=h_config["mpa_pkl"],
+        mpa_db=h_config["mpa_bt2_db_prefix"],
+    shell:
+        """
+        cat {input.read1} {input.read2} > concat_input_reads.fq.gz \
+        && \
+        humann2 \
+            --input concat_input_reads.fq.gz \
+            --output {params.outdir} \
+            --nucleotide-database {params.nucleotide_db} \
+            --protein-database {params.protein_db} \
+            --output-basename {wildcards.sample} \
+            --threads {threads} \
+            {params.taxonomic_profile} \
+            --metaphlan-options="-t rel_ab --mpa_pkl {params.mpa_pkl} --bowtie2db {params.mpa_db}" \
+            > {log.stdout} \
+            2> {log.stderr}
+        """
+
+
+rule normalize_humann2_tables:
+    """Normalize abundance tables from HUMAnN2."""
+    input:
+        genefamilies=OUTDIR/"humann2/{sample}_genefamilies.tsv",
+        pathabundance=OUTDIR/"humann2/{sample}_pathabundance.tsv",
+    output:
+        genefamilies=OUTDIR/"humann2/{{sample}}_genefamilies_{method}.tsv".format(method=h_config["norm_method"]),
+        pathabundance=OUTDIR/"humann2/{{sample}}_pathabundance_{method}.tsv".format(method=h_config["norm_method"]),
+    log:
+        stdout=str(LOGDIR/"humann2/{sample}.humann2_sample_normalize.stdout.log"),
+        stderr=str(LOGDIR/"humann2/{sample}.humann2_sample_normalize.stderr.log"),
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/biobakery.yaml"
+    threads: 
+        1
+    params:
+        method=h_config["norm_method"],
+        mode=h_config["norm_mode"],
+    shell:
+        """
+        humann2_renorm_table \
+            --input {input.genefamilies} \
+            --output {output.genefamilies} \
+            --units {params.method} \
+            --mode {params.mode} \
+            > {log.stdout} \
+            2> {log.stderr}
+        humann2_renorm_table \
+            --input {input.pathabundance} \
+            --output {output.pathabundance} \
+            --units {params.method} \
+            --mode {params.mode} \
+            >> {log.stdout} \
+            2>> {log.stderr}
+        """
+
+
+rule join_humann2_tables:
+    """Join abundance tables from HUMAnN2."""
+    input:
+        genefamilies=expand(str(OUTDIR/"humann2/{{sample}}_genefamilies_{method}.tsv").format(method=h_config["norm_method"]),
+            sample=SAMPLES),
+        pathabundance=expand(str(OUTDIR/"humann2/{{sample}}_genefamilies_{method}.tsv").format(method=h_config["norm_method"]),
+            sample=SAMPLES),
+        pathcoverage=expand(str(OUTDIR/"humann2/{sample}_pathcoverage.tsv"), sample=SAMPLES),
+    output:
+        genefamilies=OUTDIR/"humann2/all_samples.humann2_genefamilies.tsv",
+        pathabundance=OUTDIR/"humann2/all_samples.humann2_pathabundance.tsv",
+        pathcoverage=OUTDIR/"humann2/all_samples.humann2_pathcoverage.tsv",
+    log:
+        stdout=str(LOGDIR/"humann2/humann2_join_tables.stdout.log"),
+        stderr=str(LOGDIR/"humann2/humann2_join_tables.stderr.log"),
+    shadow:
+        "shallow"
+    conda:
+        "../../envs/biobakery.yaml"
+    threads: 
+        1
+    params:
+        output_dir=OUTDIR/"humann2",
+        genefamilies="genefamilies_{method}".format(method=h_config["norm_method"]),
+        pathabundance="pathabundance_{method}".format(method=h_config["norm_method"]),
+    shell:
+        """
+        humann2_join_tables \
+            --input {params.output_dir} \
+            --output {output.genefamilies} \
+            --file_name {params.genefamilies} \
+            > {log.stdout} \
+            2> {log.stderr}
+        humann2_join_tables \
+            --input {params.output_dir} \
+            --output {output.pathcoverage} \
+            --file_name pathcoverage \
+            >> {log.stdout} \
+            2>> {log.stderr}
+        humann2_join_tables \
+            --input {params.output_dir} \
+            --output {output.pathabundance} \
+            --file_name {params.pathabundance} \
+            >> {log.stdout} \
+            2>> {log.stderr}
+        """
+
+
+

--- a/rules/taxonomic_profiling/metaphlan2.smk
+++ b/rules/taxonomic_profiling/metaphlan2.smk
@@ -39,7 +39,7 @@ rule download_metaphlan2_database:
     shadow:
         "shallow"
     conda:
-        "../../envs/metaphlan2.yaml"
+        "../../envs/biobakery.yaml"
     params:
         dbdir=config["dbdir"]+"/metaphlan2"
     shell:
@@ -70,7 +70,7 @@ rule build_metaphlan2_index:
     shadow:
         "shallow"
     conda:
-        "../../envs/metaphlan2.yaml"
+        "../../envs/biobakery.yaml"
     threads:
         4
     params:
@@ -100,7 +100,7 @@ rule metaphlan2:
     shadow:
         "shallow"
     conda:
-        "../../envs/metaphlan2.yaml"
+        "../../envs/biobakery.yaml"
     threads:
         4
     params:
@@ -138,7 +138,7 @@ rule combine_metaphlan2_outputs:
     shadow:
         "shallow"
     conda:
-        "../../envs/metaphlan2.yaml"
+        "../../envs/biobakery.yaml"
     threads:
         1
     params:
@@ -176,7 +176,7 @@ rule create_metaphlan2_krona_plots:
     shadow:
         "shallow"
     conda:
-        "../../envs/metaphlan2.yaml"
+        "../../envs/biobakery.yaml"
     threads:
         1
     shell:


### PR DESCRIPTION
Add rules to run [HUMAnN2](https://bitbucket.org/biobakery/humann2/) for functional profiling.

This PR adds:
* HUMAnN2 rules module
* HUMAnN2-specific settings to `config.yaml`
* documentation about the HUMAnN2 module
* updates to the changelog about adding HUMAnN2